### PR TITLE
fix: Maintain consistent vertical position for collapse buttons (#12)

### DIFF
--- a/client/src/components/CollapsiblePanel.css
+++ b/client/src/components/CollapsiblePanel.css
@@ -9,11 +9,13 @@
 .collapsible-panel.left {
   width: 320px;
   min-width: 320px;
+  height: 100%;
 }
 
 .collapsible-panel.left.collapsed {
   width: 8px;
   min-width: 8px;
+  height: 100%;
 }
 
 .collapsible-panel.left .collapse-toggle {
@@ -27,11 +29,13 @@
 .collapsible-panel.right {
   width: 320px;
   min-width: 320px;
+  height: 100%;
 }
 
 .collapsible-panel.right.collapsed {
   width: 8px;
   min-width: 8px;
+  height: 100%;
 }
 
 .collapsible-panel.right .collapse-toggle {
@@ -88,12 +92,16 @@
   background: white;
   border-radius: 8px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  height: 100%;
 }
 
 .collapsed .panel-content {
   opacity: 0;
   transform: scale(0.98);
   pointer-events: none;
+  width: 0;
+  padding: 0;
+  margin: 0;
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## Summary
Fixes the jumping behavior of the right panel's collapse button by ensuring panels maintain their full height even when collapsed.

## Problem
The right panel's collapse button would jump to a different vertical position when the panel was collapsed, creating a jarring user experience. The left panel button stayed in place correctly.

## Solution
- Added explicit `height: 100%` to both collapsed and expanded states
- Ensured panel content collapses without affecting parent container dimensions
- Both panels now consistently maintain their collapse buttons at 50% vertical position

## Testing
- [x] Right panel button stays at same vertical position when collapsed/expanded
- [x] Left panel button continues to work correctly
- [x] Smooth transitions without jumping
- [x] Both panels behave consistently

## Related Issues
Fixes #12

## Before/After
**Before**: Right panel button jumped down when collapsed
**After**: Button stays at the same vertical position, matching left panel behavior

🤖 Generated with [Claude Code](https://claude.ai/code)