### PR TITLE
fix: Real-time weight adjustment without simulation reset (#30)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -134,7 +134,8 @@ function MainSimulator() {
       // Show error in UI instead of crashing
       alert(`Failed to initialize simulation: ${error}`);
     }
-  }, [latticeSize, temperature, weights, boundaryCondition, dwbcType, seed]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [latticeSize, temperature, boundaryCondition, dwbcType, seed]);
 
   // Re-initialize when key parameters change
   useEffect(() => {

--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -671,6 +671,29 @@ export class OptimizedPhysicsSimulation {
   }
 
   /**
+   * Update weights without resetting the lattice state
+   */
+  public updateWeights(newWeights: {
+    a1: number;
+    a2: number;
+    b1: number;
+    b2: number;
+    c1: number;
+    c2: number;
+  }): void {
+    // Update internal weights array
+    this.weights[VERTEX_A1] = newWeights.a1;
+    this.weights[VERTEX_A2] = newWeights.a2;
+    this.weights[VERTEX_B1] = newWeights.b1;
+    this.weights[VERTEX_B2] = newWeights.b2;
+    this.weights[VERTEX_C1] = newWeights.c1;
+    this.weights[VERTEX_C2] = newWeights.c2;
+
+    // No need to rebuild flippable list - lattice topology unchanged
+    // The weight changes will be automatically used in the next flip attempts
+  }
+
+  /**
    * Reset simulation
    */
   public reset(): void {

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -454,6 +454,11 @@ export class MonteCarloSimulation implements SimulationController {
     if (params.temperature !== undefined) {
       this.params.beta = 1.0 / params.temperature;
     }
+
+    // Update weights in optimized simulation without resetting
+    if (params.weights && this.optimizedSim) {
+      this.optimizedSim.updateWeights(params.weights);
+    }
   }
 
   /**


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-31.dev.6v.allison.la

## Summary
Fixed the issue where adjusting vertex weights (a1, a2, b1, b2, c1, c2) causes the simulation to reset completely. Weights now update in real-time while preserving the current lattice state.

## Changes
- Removed `weights` from `initializeSimulation` useCallback dependencies in MainSimulator.tsx
- Added `updateWeights` method to OptimizedPhysicsSimulation class
- Updated `simulation.ts` to call `updateWeights` for real-time updates
- Added ESLint disable comment for intentional dependency exclusion

## Screenshots
N/A - Behavioral change only

## Testing
- [x] Manually tested weight adjustments during running simulation
- [x] Verified lattice state is preserved
- [x] Confirmed ice rule remains valid
- [x] Build passes (`npm run build`)
- [x] TypeScript compiles (`npm run typecheck`)

## Related Issues
Fixes #30

## Checklist
- [x] Code follows project conventions
- [x] Tests pass locally (`npm test`)
- [x] TypeScript compiles (`npm run typecheck`)
- [x] Documentation updated (code comments)
- [x] CI checks pass
- [x] Preview link included and tested
- [x] PR follows single responsibility principle (one concern only)

## Additional Notes
This was a regression - the UI implementation suggested real-time updates were intended, but the dependency array caused unintended resets. Now users can adjust weights and immediately observe the effect on dynamics without losing their current lattice configuration.