### PR TITLE
feat: dual simulation with height-based convergence tracking (#32)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,8 @@ import DwbcVerify from './routes/dwbcVerify';
 import { PerformanceDemo } from './routes/performanceDemo';
 import { DWBCDebug } from './routes/dwbcDebug';
 import { FlipDebug } from './routes/flipDebug';
+import { DualSimulation } from './routes/dualSimulation';
+import { HeightDemo } from './routes/heightDemo';
 import ErrorBoundary from './components/ErrorBoundary';
 import { ThemeToggle } from './components/ThemeToggle';
 
@@ -145,6 +147,8 @@ function App() {
             <Link to="/dwbc-verify">DWBC Verify</Link>
             <Link to="/dwbc-debug">DWBC Debug</Link>
             <Link to="/flip-debug">Flip Debug</Link>
+            <Link to="/dual-simulation">Dual Sim</Link>
+            <Link to="/height-demo">Height Demo</Link>
             <Link to="/performance">Performance</Link>
             <Link to="/model-tests">Tests</Link>
             <ThemeToggle />
@@ -158,6 +162,8 @@ function App() {
           <Route path="/dwbc-verify" element={<DwbcVerify />} />
           <Route path="/dwbc-debug" element={<DWBCDebug />} />
           <Route path="/flip-debug" element={<FlipDebug />} />
+          <Route path="/dual-simulation" element={<DualSimulation />} />
+          <Route path="/height-demo" element={<HeightDemo />} />
           <Route path="/performance" element={<PerformanceDemo />} />
           <Route path="/model-tests" element={<ModelTests />} />
         </Routes>

--- a/client/src/components/DualSimulationDisplay.css
+++ b/client/src/components/DualSimulationDisplay.css
@@ -1,0 +1,125 @@
+.dual-simulation-display {
+  width: 100%;
+  /* Concrete height so the two lattice canvases have room to render. The route
+     places this in normal page flow, so height:100% would collapse to ~0. */
+  height: min(78vh, 820px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  background: transparent;
+  box-sizing: border-box;
+  min-height: 480px;
+  overflow: hidden;
+  position: relative;
+}
+
+/* Individual simulation container - exactly 50% height each */
+.simulation-container {
+  flex: 1 1 0; /* Each container takes equal space */
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  min-height: 0;
+  box-sizing: border-box;
+  position: relative;
+}
+
+/* Simulation label */
+.simulation-label {
+  flex: 0 0 auto;
+  padding: 0.5rem 1rem;
+  background: var(--color-bg-tertiary);
+  border-bottom: 1px solid var(--color-border);
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* Content area containing the PanZoomCanvas */
+.simulation-content {
+  flex: 1 1 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  position: relative;
+  box-sizing: border-box;
+}
+
+/* Override PanZoomCanvas container styles when inside simulation-content */
+.simulation-content > .pan-zoom-container {
+  width: 100%;
+  height: 100%;
+  min-height: 0; /* Critical: Allow PanZoomCanvas to shrink */
+  overflow: hidden; /* Critical: Prevent PanZoomCanvas overflow */
+  border: none !important; /* Remove any borders from PanZoomCanvas */
+  background: transparent !important;
+  box-sizing: border-box;
+}
+
+/* Canvas styling */
+.simulation-canvas {
+  display: block;
+  image-rendering: auto;
+  image-rendering: -webkit-optimize-contrast;
+}
+
+/* Loading state */
+.loading-message {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 1.125rem;
+  color: var(--color-text-secondary);
+}
+
+/* Dark mode adjustments */
+[data-theme='dark'] .simulation-container {
+  background: var(--color-bg-tertiary);
+  border-color: var(--color-border-dark);
+}
+
+[data-theme='dark'] .simulation-label {
+  background: var(--color-bg-quaternary);
+  border-color: var(--color-border-dark);
+}
+
+/* Mobile responsive */
+@media (max-width: 768px) {
+  .dual-simulation-display {
+    gap: 0.25rem;
+    padding: 0.25rem;
+  }
+
+  .simulation-label {
+    padding: 0.375rem 0.75rem;
+    font-size: 0.75rem;
+  }
+
+  .simulation-content {
+    padding: 0.25rem;
+  }
+}
+
+/* High resolution displays */
+@media (min-width: 1920px) {
+  .dual-simulation-display {
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  .simulation-label {
+    padding: 0.625rem 1.25rem;
+    font-size: 1rem;
+  }
+}

--- a/client/src/components/DualSimulationDisplay.tsx
+++ b/client/src/components/DualSimulationDisplay.tsx
@@ -1,0 +1,185 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import type { LatticeState } from '../lib/six-vertex/types';
+import { PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
+import { RenderMode } from '../lib/six-vertex/types';
+import './DualSimulationDisplay.css';
+
+interface DualSimulationDisplayProps {
+  latticeA: LatticeState | null;
+  latticeB: LatticeState | null;
+  showArrows: boolean;
+  cellSize: number;
+}
+
+export function DualSimulationDisplay({
+  latticeA,
+  latticeB,
+  showArrows,
+  cellSize: baseCellSize,
+}: DualSimulationDisplayProps) {
+  const canvasARef = useRef<HTMLCanvasElement>(null);
+  const canvasBRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Calculate canvas dimensions based on lattice size
+  const [dimensions, setDimensions] = useState({
+    canvasWidth: latticeA ? latticeA.width * baseCellSize : 400,
+    canvasHeight: latticeA ? latticeA.height * baseCellSize : 400,
+    cellSize: baseCellSize,
+  });
+
+  // Calculate optimal dimensions to fill available space
+  const updateDimensions = useCallback(() => {
+    if (!containerRef.current || !latticeA) return;
+
+    const container = containerRef.current;
+    const containerRect = container.getBoundingClientRect();
+
+    // Validate container dimensions are reasonable
+    if (containerRect.width < 100 || containerRect.height < 100) {
+      return;
+    }
+
+    // Get the actual computed styles to account for padding
+    const containerStyles = window.getComputedStyle(container);
+    const containerPaddingH =
+      parseFloat(containerStyles.paddingLeft) + parseFloat(containerStyles.paddingRight);
+    const containerPaddingV =
+      parseFloat(containerStyles.paddingTop) + parseFloat(containerStyles.paddingBottom);
+
+    // Calculate available space accounting for container padding and gap
+    const gap = 8; // Gap between simulation containers
+    const labelHeight = 32; // Height for each simulation label
+    const containerBorder = 2; // Border width for each container
+    const containerPadding = 16; // Padding inside each container
+    const availableWidth = containerRect.width - containerPaddingH;
+    const availableHeight = containerRect.height - containerPaddingV;
+
+    // Each simulation container gets half the height minus gap
+    const containerHeight = (availableHeight - gap) / 2;
+    // Subtract label, borders, and padding from container height for canvas area
+    const effectiveHeightPerSimulation =
+      containerHeight - labelHeight - containerBorder * 2 - containerPadding * 2;
+    // Width accounting for container borders and padding
+    const effectiveWidth = availableWidth - containerBorder * 2 - containerPadding * 2;
+
+    // Calculate the optimal cell size to fit within viewport
+    // Use a higher factor to maximize space usage
+    const maxCellSizeByWidth = effectiveWidth / latticeA.width;
+    const maxCellSizeByHeight = effectiveHeightPerSimulation / latticeA.height;
+
+    // Choose the limiting dimension
+    const optimalCellSize = Math.min(maxCellSizeByWidth, maxCellSizeByHeight);
+
+    // Set minimum and maximum cell sizes
+    const MIN_CELL_SIZE = 8;
+    const MAX_CELL_SIZE = 80;
+
+    // Clamp the cell size within reasonable bounds
+    const finalCellSize = Math.floor(
+      Math.max(MIN_CELL_SIZE, Math.min(MAX_CELL_SIZE, optimalCellSize)),
+    );
+
+    // Calculate actual canvas dimensions
+    const canvasWidth = Math.floor(latticeA.width * finalCellSize);
+    const canvasHeight = Math.floor(latticeA.height * finalCellSize);
+
+    setDimensions({
+      canvasWidth,
+      canvasHeight,
+      cellSize: finalCellSize,
+    });
+  }, [latticeA]);
+
+  // Setup resize observer
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      // Only update if the container has meaningful dimensions
+      for (const entry of entries) {
+        if (entry.contentRect.width > 100 && entry.contentRect.height > 100) {
+          updateDimensions();
+        }
+      }
+    });
+
+    resizeObserver.observe(containerRef.current);
+
+    // Single update after DOM settles
+    const timeoutId = setTimeout(() => {
+      updateDimensions();
+    }, 10);
+
+    return () => {
+      clearTimeout(timeoutId);
+      resizeObserver.disconnect();
+    };
+  }, [updateDimensions]);
+
+  // Render simulation A
+  useEffect(() => {
+    if (!latticeA || !canvasARef.current) return;
+
+    const renderer = new PathRenderer(canvasARef.current, {
+      cellSize: dimensions.cellSize,
+      mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
+    });
+    renderer.render(latticeA);
+  }, [latticeA, showArrows, dimensions.cellSize]);
+
+  // Render simulation B
+  useEffect(() => {
+    if (!latticeB || !canvasBRef.current) return;
+
+    const renderer = new PathRenderer(canvasBRef.current, {
+      cellSize: dimensions.cellSize,
+      mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
+    });
+    renderer.render(latticeB);
+  }, [latticeB, showArrows, dimensions.cellSize]);
+
+  if (!latticeA || !latticeB) {
+    return (
+      <div className="dual-simulation-display">
+        <div className="loading-message">Initializing simulations...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="dual-simulation-display" ref={containerRef}>
+      {/* Simulation A Container */}
+      <div className="simulation-container">
+        <div className="simulation-label">Simulation A</div>
+        <div className="simulation-content">
+          <canvas
+            ref={canvasARef}
+            width={dimensions.canvasWidth}
+            height={dimensions.canvasHeight}
+            className="simulation-canvas"
+            style={{
+              display: 'block',
+            }}
+          />
+        </div>
+      </div>
+
+      {/* Simulation B Container */}
+      <div className="simulation-container">
+        <div className="simulation-label">Simulation B</div>
+        <div className="simulation-content">
+          <canvas
+            ref={canvasBRef}
+            width={dimensions.canvasWidth}
+            height={dimensions.canvasHeight}
+            className="simulation-canvas"
+            style={{
+              display: 'block',
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/lib/six-vertex/dualSimulation.ts
+++ b/client/src/lib/six-vertex/dualSimulation.ts
@@ -1,0 +1,282 @@
+/**
+ * Dual simulation manager for running two 6-vertex simulations in parallel
+ * with convergence tracking based on height function similarity
+ */
+
+import { OptimizedPhysicsSimulation as OptimizedSimulation } from './optimizedSimulation';
+import { calculateHeightFunction } from './heightFunction';
+import type { LatticeState, DWBCConfig } from './types';
+import type { HeightData } from './heightFunction';
+
+export interface DualSimulationConfig {
+  size: number;
+  temperature: number;
+  weights: {
+    a1: number;
+    a2: number;
+    b1: number;
+    b2: number;
+    c1: number;
+    c2: number;
+  };
+  seedA: number;
+  seedB: number;
+  configA: DWBCConfig;
+  configB: DWBCConfig;
+}
+
+export interface SimulationStats {
+  flipAttempts: number;
+  flipSuccesses: number;
+  flipFailures: number;
+  totalSteps: number;
+  heightData: HeightData | null;
+}
+
+export interface ConvergenceMetrics {
+  volumeDifference: number;
+  volumeRatio: number;
+  averageHeightDifference: number;
+  isConverged: boolean;
+  convergenceThreshold: number;
+  historyLength: number;
+  smoothedDifference: number;
+}
+
+export class DualSimulationManager {
+  private simulationA: OptimizedSimulation;
+  private simulationB: OptimizedSimulation;
+  private config: DualSimulationConfig;
+  private convergenceHistory: number[] = [];
+  private readonly HISTORY_SIZE = 100;
+  private readonly CONVERGENCE_THRESHOLD = 0.05; // 5% difference threshold
+
+  constructor(config: DualSimulationConfig) {
+    this.config = config;
+
+    // Initialize simulation A
+    this.simulationA = new OptimizedSimulation({
+      size: config.size,
+      weights: config.weights,
+      beta: 1 / config.temperature,
+      seed: config.seedA,
+      initialState: config.configA.type === 'high' ? 'dwbc-high' : 'dwbc-low',
+    });
+
+    // Initialize simulation B
+    this.simulationB = new OptimizedSimulation({
+      size: config.size,
+      weights: config.weights,
+      beta: 1 / config.temperature,
+      seed: config.seedB,
+      initialState: config.configB.type === 'high' ? 'dwbc-high' : 'dwbc-low',
+    });
+  }
+
+  /**
+   * Step both simulations forward
+   */
+  public step(stepsPerFrame: number = 100): void {
+    this.simulationA.run(stepsPerFrame);
+    this.simulationB.run(stepsPerFrame);
+  }
+
+  /**
+   * Get the current state of simulation A
+   */
+  public getLatticeA(): LatticeState {
+    return this.simulationA.getState();
+  }
+
+  /**
+   * Get the current state of simulation B
+   */
+  public getLatticeB(): LatticeState {
+    return this.simulationB.getState();
+  }
+
+  /**
+   * Get statistics for simulation A
+   */
+  public getStatsA(): SimulationStats {
+    const lattice = this.getLatticeA();
+    const heightData = calculateHeightFunction(lattice);
+    const stats = this.simulationA.getStats();
+
+    return {
+      flipAttempts: stats.flipAttempts,
+      flipSuccesses: stats.successfulFlips,
+      flipFailures: stats.flipAttempts - stats.successfulFlips,
+      totalSteps: stats.step,
+      heightData,
+    };
+  }
+
+  /**
+   * Get statistics for simulation B
+   */
+  public getStatsB(): SimulationStats {
+    const lattice = this.getLatticeB();
+    const heightData = calculateHeightFunction(lattice);
+    const stats = this.simulationB.getStats();
+
+    return {
+      flipAttempts: stats.flipAttempts,
+      flipSuccesses: stats.successfulFlips,
+      flipFailures: stats.flipAttempts - stats.successfulFlips,
+      totalSteps: stats.step,
+      heightData,
+    };
+  }
+
+  /**
+   * Calculate convergence metrics between the two simulations
+   */
+  public getConvergenceMetrics(): ConvergenceMetrics {
+    const statsA = this.getStatsA();
+    const statsB = this.getStatsB();
+
+    if (!statsA.heightData || !statsB.heightData) {
+      return {
+        volumeDifference: 0,
+        volumeRatio: 1,
+        averageHeightDifference: 0,
+        isConverged: false,
+        convergenceThreshold: this.CONVERGENCE_THRESHOLD,
+        historyLength: 0,
+        smoothedDifference: 0,
+      };
+    }
+
+    const volumeA = statsA.heightData.totalVolume;
+    const volumeB = statsB.heightData.totalVolume;
+    const avgHeightA = statsA.heightData.averageHeight;
+    const avgHeightB = statsB.heightData.averageHeight;
+
+    // Calculate metrics
+    const volumeDifference = Math.abs(volumeA - volumeB);
+    const volumeRatio = Math.min(volumeA, volumeB) / Math.max(volumeA, volumeB);
+    const averageHeightDifference = Math.abs(avgHeightA - avgHeightB);
+
+    // Normalized difference (0 to 1)
+    const normalizedDiff = volumeDifference / Math.max(volumeA, volumeB);
+
+    // Update history
+    this.convergenceHistory.push(normalizedDiff);
+    if (this.convergenceHistory.length > this.HISTORY_SIZE) {
+      this.convergenceHistory.shift();
+    }
+
+    // Calculate smoothed difference (moving average)
+    const smoothedDifference =
+      this.convergenceHistory.length > 0
+        ? this.convergenceHistory.reduce((a, b) => a + b, 0) / this.convergenceHistory.length
+        : normalizedDiff;
+
+    // Check convergence: volume ratio close to 1 and stable
+    const isConverged =
+      volumeRatio > 1 - this.CONVERGENCE_THRESHOLD &&
+      smoothedDifference < this.CONVERGENCE_THRESHOLD &&
+      this.convergenceHistory.length >= 20; // Need enough history
+
+    return {
+      volumeDifference,
+      volumeRatio,
+      averageHeightDifference,
+      isConverged,
+      convergenceThreshold: this.CONVERGENCE_THRESHOLD,
+      historyLength: this.convergenceHistory.length,
+      smoothedDifference,
+    };
+  }
+
+  /**
+   * Update weights for both simulations
+   */
+  public updateWeights(newWeights: {
+    a1: number;
+    a2: number;
+    b1: number;
+    b2: number;
+    c1: number;
+    c2: number;
+  }): void {
+    this.simulationA.updateWeights(newWeights);
+    this.simulationB.updateWeights(newWeights);
+    this.config.weights = newWeights;
+  }
+
+  /**
+   * Update temperature for both simulations
+   * Note: OptimizedSimulation doesn't support temperature updates,
+   * so we need to recreate the simulations
+   */
+  public updateTemperature(temperature: number): void {
+    this.config.temperature = temperature;
+    // Recreate simulations with new temperature
+    this.reset();
+  }
+
+  /**
+   * Reset both simulations with new configurations
+   */
+  public reset(configA?: DWBCConfig, configB?: DWBCConfig): void {
+    if (configA) {
+      this.config.configA = configA;
+    }
+    if (configB) {
+      this.config.configB = configB;
+    }
+
+    // Reset simulation A
+    this.simulationA = new OptimizedSimulation({
+      size: this.config.size,
+      weights: this.config.weights,
+      beta: 1 / this.config.temperature,
+      seed: this.config.seedA,
+      initialState: this.config.configA.type === 'high' ? 'dwbc-high' : 'dwbc-low',
+    });
+
+    // Reset simulation B
+    this.simulationB = new OptimizedSimulation({
+      size: this.config.size,
+      weights: this.config.weights,
+      beta: 1 / this.config.temperature,
+      seed: this.config.seedB,
+      initialState: this.config.configB.type === 'high' ? 'dwbc-high' : 'dwbc-low',
+    });
+
+    // Clear convergence history
+    this.convergenceHistory = [];
+  }
+
+  /**
+   * Get convergence history for visualization
+   */
+  public getConvergenceHistory(): number[] {
+    return [...this.convergenceHistory];
+  }
+
+  /**
+   * Check if both simulations have reached equilibrium
+   * (based on flip success rate stability)
+   */
+  public isEquilibrated(): boolean {
+    // Simple check: both simulations have reasonable flip success rates
+    const statsA = this.simulationA.getStats();
+    const statsB = this.simulationB.getStats();
+
+    const successRateA = statsA.acceptanceRate;
+    const successRateB = statsB.acceptanceRate;
+
+    // Typical equilibrium success rates are between 0.3 and 0.7
+    return (
+      successRateA > 0.2 &&
+      successRateA < 0.8 &&
+      successRateB > 0.2 &&
+      successRateB < 0.8 &&
+      statsA.step > 1000 &&
+      statsB.step > 1000
+    );
+  }
+}

--- a/client/src/lib/six-vertex/heightFunction.ts
+++ b/client/src/lib/six-vertex/heightFunction.ts
@@ -1,0 +1,363 @@
+/**
+ * Height function calculator for the 6-vertex model
+ *
+ * Based on the paper's definition:
+ * The height at a vertex is defined as the cumulative count of certain edge crossings
+ * when traveling from the origin (0,0) to that vertex.
+ *
+ * Specifically:
+ * - When a vertex has an edge pointing LEFT (into the vertex), add +1 to the height
+ * - When a vertex has an edge pointing DOWN (into the vertex), add +1 to the height
+ *
+ * The total volume is the sum of all vertex heights in the lattice.
+ */
+
+import { EdgeState } from './types';
+import type { LatticeState, Vertex } from './types';
+
+/**
+ * Height data for the entire lattice
+ */
+export interface HeightData {
+  /** 2D array of heights at each vertex position */
+  heights: number[][];
+  /** Total volume (sum of all heights) */
+  totalVolume: number;
+  /** Minimum height value in the lattice */
+  minHeight: number;
+  /** Maximum height value in the lattice */
+  maxHeight: number;
+  /** Average height across all vertices */
+  averageHeight: number;
+}
+
+/**
+ * Height contribution for a single vertex
+ */
+export interface VertexHeightContribution {
+  /** Contribution from left edge */
+  fromLeft: number;
+  /** Contribution from top edge */
+  fromTop: number;
+  /** Total contribution at this vertex */
+  total: number;
+}
+
+/**
+ * Calculate the height function for the entire lattice
+ *
+ * The height is calculated by accumulating contributions as we traverse
+ * from the origin (0,0) to each vertex position.
+ *
+ * @param lattice - The current lattice state
+ * @returns Height data including individual heights and statistics
+ */
+export function calculateHeightFunction(lattice: LatticeState): HeightData {
+  const { width, height } = lattice;
+
+  // Initialize height array
+  const heights: number[][] = Array(height)
+    .fill(null)
+    .map(() => Array(width).fill(0));
+
+  // Calculate heights using a cumulative path-sum from the top-left (0,0).
+  // We read each vertex's configuration (which is always present and is the
+  // source of truth) rather than the lattice edge arrays, which some lattice
+  // producers (e.g. the optimized simulation engine) leave empty.
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const config = lattice.vertices[row][col].configuration;
+
+      // Start with height from above (if not first row)
+      if (row > 0) {
+        heights[row][col] = heights[row - 1][col];
+
+        // The shared vertical edge is this vertex's top edge. An incoming
+        // (downward) top edge raises the height by 1.
+        if (config.top === EdgeState.In) {
+          heights[row][col] += 1;
+        }
+      }
+
+      // Add height from left (if not first column)
+      if (col > 0) {
+        // For first row, just use left neighbor's height
+        // For other rows, we already have contribution from above
+        if (row === 0) {
+          heights[row][col] = heights[row][col - 1];
+        }
+
+        // The shared horizontal edge is this vertex's left edge. A left-pointing
+        // (outgoing-left) edge raises the height by 1.
+        if (config.left === EdgeState.Out) {
+          heights[row][col] += 1;
+        }
+      }
+    }
+  }
+
+  // Calculate statistics
+  let totalVolume = 0;
+  let minHeight = Infinity;
+  let maxHeight = -Infinity;
+
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const h = heights[row][col];
+      totalVolume += h;
+      minHeight = Math.min(minHeight, h);
+      maxHeight = Math.max(maxHeight, h);
+    }
+  }
+
+  const averageHeight = totalVolume / (width * height);
+
+  return {
+    heights,
+    totalVolume,
+    minHeight,
+    maxHeight,
+    averageHeight,
+  };
+}
+
+/**
+ * Calculate the height contribution at a specific vertex
+ * This is useful for understanding how a vertex's configuration affects the height
+ *
+ * @param vertex - The vertex to analyze
+ * @returns The height contributions from each direction
+ */
+export function getVertexHeightContribution(vertex: Vertex): VertexHeightContribution {
+  const { configuration } = vertex;
+
+  let fromLeft = 0;
+  let fromTop = 0;
+
+  // Check if left edge points into the vertex (contributes +1)
+  if (configuration.left === EdgeState.In) {
+    fromLeft = 1;
+  }
+
+  // Check if top edge points into the vertex (contributes +1)
+  if (configuration.top === EdgeState.In) {
+    fromTop = 1;
+  }
+
+  return {
+    fromLeft,
+    fromTop,
+    total: fromLeft + fromTop,
+  };
+}
+
+/**
+ * Calculate height difference between two adjacent vertices
+ * Useful for understanding local height gradients
+ *
+ * @param heightData - The complete height data
+ * @param from - Source position {row, col}
+ * @param to - Target position {row, col}
+ * @returns Height difference (to - from), or null if positions are invalid
+ */
+export function getHeightDifference(
+  heightData: HeightData,
+  from: { row: number; col: number },
+  to: { row: number; col: number },
+): number | null {
+  const { heights } = heightData;
+
+  // Validate positions
+  if (
+    from.row < 0 ||
+    from.row >= heights.length ||
+    from.col < 0 ||
+    from.col >= heights[0].length ||
+    to.row < 0 ||
+    to.row >= heights.length ||
+    to.col < 0 ||
+    to.col >= heights[0].length
+  ) {
+    return null;
+  }
+
+  return heights[to.row][to.col] - heights[from.row][from.col];
+}
+
+/**
+ * Get height profile along a row or column
+ * Useful for visualization and analysis
+ *
+ * @param heightData - The complete height data
+ * @param direction - 'row' or 'column'
+ * @param index - The row or column index
+ * @returns Array of heights along the specified line
+ */
+export function getHeightProfile(
+  heightData: HeightData,
+  direction: 'row' | 'column',
+  index: number,
+): number[] {
+  const { heights } = heightData;
+
+  if (direction === 'row') {
+    if (index < 0 || index >= heights.length) {
+      return [];
+    }
+    return [...heights[index]];
+  } else {
+    if (index < 0 || index >= heights[0].length) {
+      return [];
+    }
+    return heights.map((row) => row[index]);
+  }
+}
+
+/**
+ * Calculate the height function gradient at each vertex
+ * Returns the discrete gradient (difference with neighbors)
+ *
+ * @param heightData - The complete height data
+ * @returns 2D array of gradient vectors {dx, dy} at each vertex
+ */
+export function calculateHeightGradient(
+  heightData: HeightData,
+): Array<Array<{ dx: number; dy: number }>> {
+  const { heights } = heightData;
+  const numRows = heights.length;
+  const numCols = heights[0].length;
+
+  const gradient: Array<Array<{ dx: number; dy: number }>> = Array(numRows)
+    .fill(null)
+    .map(() =>
+      Array(numCols)
+        .fill(null)
+        .map(() => ({ dx: 0, dy: 0 })),
+    );
+
+  for (let row = 0; row < numRows; row++) {
+    for (let col = 0; col < numCols; col++) {
+      const currentHeight = heights[row][col];
+
+      // Calculate horizontal gradient (dx)
+      if (col > 0 && col < numCols - 1) {
+        gradient[row][col].dx = (heights[row][col + 1] - heights[row][col - 1]) / 2;
+      } else if (col === 0 && numCols > 1) {
+        gradient[row][col].dx = heights[row][1] - currentHeight;
+      } else if (col === numCols - 1 && numCols > 1) {
+        gradient[row][col].dx = currentHeight - heights[row][col - 1];
+      }
+
+      // Calculate vertical gradient (dy)
+      if (row > 0 && row < numRows - 1) {
+        gradient[row][col].dy = (heights[row + 1][col] - heights[row - 1][col]) / 2;
+      } else if (row === 0 && numRows > 1) {
+        gradient[row][col].dy = heights[1][col] - currentHeight;
+      } else if (row === numRows - 1 && numRows > 1) {
+        gradient[row][col].dy = currentHeight - heights[row - 1][col];
+      }
+    }
+  }
+
+  return gradient;
+}
+
+/**
+ * Verify that the height function is consistent with the vertex configurations
+ * This is a debugging tool to ensure the height calculation is correct
+ *
+ * @param lattice - The lattice state
+ * @param heightData - The calculated height data
+ * @returns True if the height function is consistent, false otherwise
+ */
+export function verifyHeightConsistency(
+  lattice: LatticeState,
+  heightData: HeightData,
+): { isConsistent: boolean; errors: string[] } {
+  const errors: string[] = [];
+  const { width, height } = lattice;
+  const { heights } = heightData;
+
+  // Verify dimensions match
+  if (heights.length !== height || heights[0].length !== width) {
+    errors.push(
+      `Dimension mismatch: lattice is ${height}x${width}, heights is ${heights.length}x${heights[0].length}`,
+    );
+    return { isConsistent: false, errors };
+  }
+
+  // Verify height differences match edge configurations
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const currentHeight = heights[row][col];
+
+      // Check horizontal edge consistency
+      if (col < width - 1) {
+        const rightHeight = heights[row][col + 1];
+        const horizontalEdge = lattice.horizontalEdges[row][col];
+        const expectedDiff = horizontalEdge === EdgeState.Out ? 1 : 0;
+        const actualDiff = rightHeight - currentHeight;
+
+        if (actualDiff !== expectedDiff && actualDiff !== expectedDiff - 1) {
+          // Allow for boundary effects
+          errors.push(
+            `Height inconsistency at (${row},${col}): horizontal edge is ${horizontalEdge}, ` +
+              `but height difference is ${actualDiff} (expected ~${expectedDiff})`,
+          );
+        }
+      }
+
+      // Check vertical edge consistency
+      if (row < height - 1) {
+        const belowHeight = heights[row + 1][col];
+        const verticalEdge = lattice.verticalEdges[row][col];
+        const expectedDiff = verticalEdge === EdgeState.In ? 1 : 0;
+        const actualDiff = belowHeight - currentHeight;
+
+        if (actualDiff !== expectedDiff && actualDiff !== expectedDiff - 1) {
+          // Allow for boundary effects
+          errors.push(
+            `Height inconsistency at (${row},${col}): vertical edge is ${verticalEdge}, ` +
+              `but height difference is ${actualDiff} (expected ~${expectedDiff})`,
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    isConsistent: errors.length === 0,
+    errors,
+  };
+}
+
+/**
+ * Export height data to a format suitable for visualization or analysis
+ *
+ * @param heightData - The height data to export
+ * @returns JSON-serializable object with height information
+ */
+export function exportHeightData(heightData: HeightData): {
+  heights: number[][];
+  stats: {
+    totalVolume: number;
+    minHeight: number;
+    maxHeight: number;
+    averageHeight: number;
+    dimensions: { rows: number; cols: number };
+  };
+} {
+  return {
+    heights: heightData.heights.map((row) => [...row]),
+    stats: {
+      totalVolume: heightData.totalVolume,
+      minHeight: heightData.minHeight,
+      maxHeight: heightData.maxHeight,
+      averageHeight: heightData.averageHeight,
+      dimensions: {
+        rows: heightData.heights.length,
+        cols: heightData.heights[0].length,
+      },
+    },
+  };
+}

--- a/client/src/routes/dualSimulation.tsx
+++ b/client/src/routes/dualSimulation.tsx
@@ -1,0 +1,398 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import { DualSimulationManager } from '../lib/six-vertex/dualSimulation';
+import { DualSimulationDisplay } from '../components/DualSimulationDisplay';
+import type { DualSimulationConfig, ConvergenceMetrics } from '../lib/six-vertex/dualSimulation';
+import type { LatticeState } from '../lib/six-vertex/types';
+import '../App.css';
+
+export function DualSimulation() {
+  const [size, setSize] = useState(16);
+  const [temperature, setTemperature] = useState(0.5);
+  const [weights, setWeights] = useState({
+    a1: 1,
+    a2: 1,
+    b1: 1,
+    b2: 1,
+    c1: 1,
+    c2: 1,
+  });
+  const [isRunning, setIsRunning] = useState(false);
+  const [showArrows, setShowArrows] = useState(false);
+  const [stepsPerFrame, setStepsPerFrame] = useState(100);
+
+  const [latticeA, setLatticeA] = useState<LatticeState | null>(null);
+  const [latticeB, setLatticeB] = useState<LatticeState | null>(null);
+  const [metrics, setMetrics] = useState<ConvergenceMetrics | null>(null);
+
+  const managerRef = useRef<DualSimulationManager | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+
+  // Initialize dual simulation
+  const initializeSimulation = useCallback(() => {
+    const config: DualSimulationConfig = {
+      size,
+      temperature,
+      weights,
+      seedA: Math.floor(Math.random() * 1000000),
+      seedB: Math.floor(Math.random() * 1000000),
+      configA: { type: 'high' },
+      configB: { type: 'low' },
+    };
+
+    managerRef.current = new DualSimulationManager(config);
+
+    // Get initial states
+    setLatticeA(managerRef.current.getLatticeA());
+    setLatticeB(managerRef.current.getLatticeB());
+    setMetrics(managerRef.current.getConvergenceMetrics());
+  }, [size, temperature, weights]);
+
+  // Animation loop
+  const animate = useCallback(() => {
+    if (!managerRef.current || !isRunning) return;
+
+    // Step the simulation
+    managerRef.current.step(stepsPerFrame);
+
+    // Update states
+    setLatticeA(managerRef.current.getLatticeA());
+    setLatticeB(managerRef.current.getLatticeB());
+
+    // Check for auto-stop on convergence
+    const currentMetrics = managerRef.current.getConvergenceMetrics();
+    setMetrics(currentMetrics);
+    if (currentMetrics.isConverged) {
+      setIsRunning(false);
+      return;
+    }
+
+    // Continue animation
+    animationFrameRef.current = requestAnimationFrame(animate);
+  }, [isRunning, stepsPerFrame]);
+
+  // Start/stop animation
+  useEffect(() => {
+    if (isRunning) {
+      animationFrameRef.current = requestAnimationFrame(animate);
+    } else if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+    };
+  }, [isRunning, animate]);
+
+  // Initialize on mount
+  useEffect(() => {
+    initializeSimulation();
+  }, [initializeSimulation]);
+
+  // Update weights in real-time
+  const handleWeightChange = (type: keyof typeof weights, value: number) => {
+    const newWeights = { ...weights, [type]: value };
+    setWeights(newWeights);
+
+    if (managerRef.current) {
+      managerRef.current.updateWeights(newWeights);
+    }
+  };
+
+  // Update temperature in real-time
+  const handleTemperatureChange = (value: number) => {
+    setTemperature(value);
+
+    if (managerRef.current) {
+      managerRef.current.updateTemperature(value);
+    }
+  };
+
+  // Reset simulations
+  const handleReset = () => {
+    setIsRunning(false);
+    initializeSimulation();
+  };
+
+  // Swap configurations
+  const handleSwapConfigs = () => {
+    if (!managerRef.current) return;
+
+    setIsRunning(false);
+    managerRef.current.reset(
+      { type: 'low' }, // A gets Low
+      { type: 'high' }, // B gets High
+    );
+
+    // Update states
+    setLatticeA(managerRef.current.getLatticeA());
+    setLatticeB(managerRef.current.getLatticeB());
+  };
+
+  const cellSize = Math.min(20, 400 / size);
+
+  return (
+    <div className="dual-simulation-page" style={{ padding: '20px' }}>
+      <h1>Dual Simulation with Convergence Tracking</h1>
+
+      <div
+        className="control-panel"
+        style={{
+          background: 'var(--panel-bg)',
+          padding: '20px',
+          borderRadius: '8px',
+          marginBottom: '20px',
+        }}
+      >
+        <div
+          className="controls-grid"
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            gap: '15px',
+          }}
+        >
+          {/* Size control */}
+          <div className="control-group">
+            <label>
+              Lattice Size: {size}×{size}
+              <input
+                type="range"
+                min="8"
+                max="32"
+                value={size}
+                onChange={(e) => setSize(Number(e.target.value))}
+                disabled={isRunning}
+              />
+            </label>
+          </div>
+
+          {/* Temperature control */}
+          <div className="control-group">
+            <label>
+              Temperature: {temperature.toFixed(2)}
+              <input
+                type="range"
+                min="0.1"
+                max="2"
+                step="0.1"
+                value={temperature}
+                onChange={(e) => handleTemperatureChange(Number(e.target.value))}
+              />
+            </label>
+          </div>
+
+          {/* Steps per frame */}
+          <div className="control-group">
+            <label>
+              Speed: {stepsPerFrame} steps/frame
+              <input
+                type="range"
+                min="10"
+                max="1000"
+                step="10"
+                value={stepsPerFrame}
+                onChange={(e) => setStepsPerFrame(Number(e.target.value))}
+              />
+            </label>
+          </div>
+
+          {/* Show arrows toggle */}
+          <div className="control-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={showArrows}
+                onChange={(e) => setShowArrows(e.target.checked)}
+              />
+              Show Arrows
+            </label>
+          </div>
+        </div>
+
+        {/* Weight controls */}
+        <div className="weights-section" style={{ marginTop: '20px' }}>
+          <h3>Vertex Weights</h3>
+          <div
+            className="weights-grid"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: '10px',
+            }}
+          >
+            {Object.entries(weights).map(([type, value]) => (
+              <label key={type}>
+                {type.toUpperCase()}: {value.toFixed(1)}
+                <input
+                  type="range"
+                  min="0.1"
+                  max="2"
+                  step="0.1"
+                  value={value}
+                  onChange={(e) =>
+                    handleWeightChange(type as keyof typeof weights, Number(e.target.value))
+                  }
+                />
+              </label>
+            ))}
+          </div>
+        </div>
+
+        {/* Action buttons */}
+        <div
+          className="action-buttons"
+          style={{
+            marginTop: '20px',
+            display: 'flex',
+            gap: '10px',
+          }}
+        >
+          <button
+            onClick={() => setIsRunning(!isRunning)}
+            style={{
+              padding: '10px 20px',
+              background: isRunning ? 'var(--red-500)' : 'var(--green-500)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            {isRunning ? 'Stop' : 'Start'}
+          </button>
+
+          <button
+            onClick={handleReset}
+            style={{
+              padding: '10px 20px',
+              background: 'var(--blue-500)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+            }}
+          >
+            Reset
+          </button>
+
+          <button
+            onClick={handleSwapConfigs}
+            disabled={isRunning}
+            style={{
+              padding: '10px 20px',
+              background: 'var(--purple-500)',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              cursor: 'pointer',
+              opacity: isRunning ? 0.5 : 1,
+            }}
+          >
+            Swap Configs
+          </button>
+        </div>
+      </div>
+
+      {/* Dual simulation display */}
+      <DualSimulationDisplay
+        latticeA={latticeA}
+        latticeB={latticeB}
+        showArrows={showArrows}
+        cellSize={cellSize}
+      />
+
+      {/* Live convergence metrics */}
+      {metrics && (
+        <div
+          className="convergence-panel"
+          style={{
+            marginTop: '20px',
+            padding: '16px 20px',
+            background: 'var(--panel-bg)',
+            borderRadius: '8px',
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+            gap: '12px',
+            alignItems: 'center',
+          }}
+        >
+          <div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Convergence</div>
+            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
+              {(metrics.volumeRatio * 100).toFixed(1)}%
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Volume difference</div>
+            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
+              {metrics.volumeDifference.toFixed(1)}
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Avg height diff</div>
+            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
+              {metrics.averageHeightDifference.toFixed(3)}
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Smoothed diff</div>
+            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
+              {metrics.smoothedDifference.toFixed(2)}
+            </div>
+          </div>
+          <div>
+            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Status</div>
+            <div
+              style={{
+                fontSize: '1rem',
+                fontWeight: 700,
+                color: metrics.isConverged
+                  ? 'var(--green-500, #22c55e)'
+                  : 'var(--text-secondary, #888)',
+              }}
+            >
+              {metrics.isConverged ? 'Converged ✓' : isRunning ? 'Running…' : 'Not converged'}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Information panel */}
+      <div
+        className="info-panel"
+        style={{
+          marginTop: '20px',
+          padding: '20px',
+          background: 'var(--panel-bg)',
+          borderRadius: '8px',
+        }}
+      >
+        <h3>About Dual Simulation Convergence</h3>
+        <p>
+          This demonstration runs two 6-vertex model simulations simultaneously with different
+          initial conditions (DWBC High and Low). The convergence tracking monitors when the height
+          functions of both simulations reach similar values, indicating that the systems have
+          equilibrated to comparable macroscopic states despite different starting configurations.
+        </p>
+        <ul>
+          <li>
+            <strong>Volume</strong>: The total sum of all vertex heights in the lattice
+          </li>
+          <li>
+            <strong>Average Height</strong>: The mean height across all vertices
+          </li>
+          <li>
+            <strong>Convergence</strong>: Achieved when volume ratio exceeds 95% and remains stable
+          </li>
+          <li>
+            <strong>Smoothed Difference</strong>: Moving average of volume differences to reduce
+            noise
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/client/src/routes/heightDemo.tsx
+++ b/client/src/routes/heightDemo.tsx
@@ -1,0 +1,243 @@
+/**
+ * Demo route to visualize the height function
+ */
+
+import React, { useState, useEffect, useCallback } from 'react';
+import { generateDWBCState } from '../lib/six-vertex/initialStates';
+import { calculateHeightFunction, type HeightData } from '../lib/six-vertex/heightFunction';
+import type { LatticeState, DWBCConfig } from '../lib/six-vertex/types';
+import '../App.css';
+
+export function HeightDemo() {
+  const [size, setSize] = useState(8);
+  const [dwbcType, setDwbcType] = useState<'high' | 'low'>('high');
+  const [lattice, setLattice] = useState<LatticeState | null>(null);
+  const [heightData, setHeightData] = useState<HeightData | null>(null);
+  const [showValues, setShowValues] = useState(true);
+  const [colorScale, setColorScale] = useState<'blue' | 'heat' | 'grayscale'>('heat');
+
+  // Generate lattice and calculate heights
+  const generateLattice = useCallback(() => {
+    const config: DWBCConfig = { type: dwbcType };
+    const newLattice = generateDWBCState(size, size, config);
+    setLattice(newLattice);
+
+    const heights = calculateHeightFunction(newLattice);
+    setHeightData(heights);
+  }, [size, dwbcType]);
+
+  useEffect(() => {
+    generateLattice();
+  }, [generateLattice]);
+
+  // Get color for height value
+  const getHeightColor = (height: number, min: number, max: number): string => {
+    const normalized = max > min ? (height - min) / (max - min) : 0;
+
+    switch (colorScale) {
+      case 'blue': {
+        const blue = Math.floor(255 * normalized);
+        const red = Math.floor(255 * (1 - normalized));
+        return `rgb(${red}, ${red}, ${blue})`;
+      }
+
+      case 'heat': {
+        // Heat map: blue -> green -> yellow -> red
+        if (normalized < 0.25) {
+          const t = normalized * 4;
+          return `rgb(0, ${Math.floor(t * 255)}, ${Math.floor(255 * (1 - t))})`;
+        } else if (normalized < 0.5) {
+          const t = (normalized - 0.25) * 4;
+          return `rgb(${Math.floor(t * 255)}, 255, 0)`;
+        } else if (normalized < 0.75) {
+          const t = (normalized - 0.5) * 4;
+          return `rgb(255, ${Math.floor(255 * (1 - t))}, 0)`;
+        } else {
+          const t = (normalized - 0.75) * 4;
+          return `rgb(255, 0, ${Math.floor(t * 128)})`;
+        }
+      }
+
+      case 'grayscale':
+      default: {
+        const gray = Math.floor(255 * normalized);
+        return `rgb(${gray}, ${gray}, ${gray})`;
+      }
+    }
+  };
+
+  if (!lattice || !heightData) {
+    return <div className="height-demo">Loading...</div>;
+  }
+
+  const cellSize = Math.min(600 / size, 60);
+
+  return (
+    <div className="height-demo" style={{ padding: '20px' }}>
+      <h1>Height Function Visualization</h1>
+
+      <div className="controls" style={{ marginBottom: '20px' }}>
+        <div style={{ marginBottom: '10px' }}>
+          <label>
+            Size:
+            <input
+              type="range"
+              min="4"
+              max="24"
+              value={size}
+              onChange={(e) => setSize(Number(e.target.value))}
+              style={{ marginLeft: '10px', marginRight: '10px' }}
+            />
+            {size}×{size}
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ marginRight: '20px' }}>
+            <input
+              type="radio"
+              value="high"
+              checked={dwbcType === 'high'}
+              onChange={() => setDwbcType('high')}
+            />
+            DWBC High
+          </label>
+          <label>
+            <input
+              type="radio"
+              value="low"
+              checked={dwbcType === 'low'}
+              onChange={() => setDwbcType('low')}
+            />
+            DWBC Low
+          </label>
+        </div>
+
+        <div style={{ marginBottom: '10px' }}>
+          <label style={{ marginRight: '20px' }}>
+            Color Scale:
+            <select
+              value={colorScale}
+              onChange={(e) => setColorScale(e.target.value as 'blue' | 'heat' | 'grayscale')}
+              style={{ marginLeft: '10px' }}
+            >
+              <option value="heat">Heat Map</option>
+              <option value="blue">Blue Scale</option>
+              <option value="grayscale">Grayscale</option>
+            </select>
+          </label>
+
+          <label>
+            <input
+              type="checkbox"
+              checked={showValues}
+              onChange={(e) => setShowValues(e.target.checked)}
+            />
+            Show Values
+          </label>
+        </div>
+
+        <button onClick={generateLattice} style={{ padding: '5px 15px' }}>
+          Regenerate
+        </button>
+      </div>
+
+      <div className="stats" style={{ marginBottom: '20px' }}>
+        <h3>Statistics</h3>
+        <p>Total Volume: {heightData.totalVolume.toFixed(2)}</p>
+        <p>Average Height: {heightData.averageHeight.toFixed(3)}</p>
+        <p>Min Height: {heightData.minHeight}</p>
+        <p>Max Height: {heightData.maxHeight}</p>
+        <p>Range: {heightData.maxHeight - heightData.minHeight}</p>
+      </div>
+
+      <div className="height-grid" style={{ display: 'inline-block' }}>
+        <h3>Height Function Heatmap</h3>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: `repeat(${size}, ${cellSize}px)`,
+            gridTemplateRows: `repeat(${size}, ${cellSize}px)`,
+            gap: '1px',
+            backgroundColor: '#e0e0e0',
+            padding: '1px',
+            border: '2px solid #333',
+          }}
+        >
+          {heightData.heights.map((row, rowIdx) =>
+            row.map((height, colIdx) => (
+              <div
+                key={`${rowIdx}-${colIdx}`}
+                style={{
+                  width: cellSize,
+                  height: cellSize,
+                  backgroundColor: getHeightColor(
+                    height,
+                    heightData.minHeight,
+                    heightData.maxHeight,
+                  ),
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  fontSize: cellSize > 30 && showValues ? `${Math.min(cellSize / 3, 14)}px` : '0',
+                  color: showValues ? '#fff' : 'transparent',
+                  fontWeight: 'bold',
+                  textShadow: showValues ? '1px 1px 2px rgba(0,0,0,0.8)' : 'none',
+                  border: '1px solid rgba(255,255,255,0.1)',
+                }}
+                title={`Position (${rowIdx},${colIdx}): Height = ${height}`}
+              >
+                {showValues && cellSize > 30 ? height : ''}
+              </div>
+            )),
+          )}
+        </div>
+
+        {/* Color scale legend */}
+        <div style={{ marginTop: '20px' }}>
+          <h4>Color Scale</h4>
+          <div
+            style={{
+              width: '300px',
+              height: '30px',
+              background: `linear-gradient(to right, ${Array.from({ length: 20 }, (_, i) => {
+                const normalized = i / 19;
+                const value =
+                  heightData.minHeight + normalized * (heightData.maxHeight - heightData.minHeight);
+                return getHeightColor(value, heightData.minHeight, heightData.maxHeight);
+              }).join(', ')})`,
+              border: '1px solid #333',
+            }}
+          />
+          <div style={{ display: 'flex', justifyContent: 'space-between', width: '300px' }}>
+            <span>{heightData.minHeight}</span>
+            <span>{((heightData.minHeight + heightData.maxHeight) / 2).toFixed(1)}</span>
+            <span>{heightData.maxHeight}</span>
+          </div>
+        </div>
+      </div>
+
+      <div style={{ marginTop: '30px' }}>
+        <h3>About the Height Function</h3>
+        <p style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+          The height function is a fundamental concept in the 6-vertex model. It is calculated by
+          counting specific edge crossings when traveling from the origin (0,0) to each vertex.
+          Specifically:
+        </p>
+        <ul style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+          <li>When an edge points LEFT into a vertex, the height increases by +1</li>
+          <li>When an edge points DOWN into a vertex, the height increases by +1</li>
+          <li>The total volume is the sum of all vertex heights</li>
+          <li>
+            The height function provides insight into the macroscopic properties of the system
+          </li>
+        </ul>
+        <p style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+          In DWBC (Domain Wall Boundary Conditions), the height function exhibits characteristic
+          patterns that differ between the "high" and "low" configurations, reflecting the
+          underlying vertex arrangements.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/client/tests/heightFunction.test.ts
+++ b/client/tests/heightFunction.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the height function calculator
+ */
+
+import {
+  calculateHeightFunction,
+  getVertexHeightContribution,
+  getHeightDifference,
+  getHeightProfile,
+  calculateHeightGradient,
+  verifyHeightConsistency,
+  exportHeightData,
+} from '../src/lib/six-vertex/heightFunction';
+import {
+  LatticeState,
+  Vertex,
+  VertexType,
+  EdgeState,
+  getVertexConfiguration,
+} from '../src/lib/six-vertex/types';
+
+/**
+ * Create a simple test lattice
+ */
+function createTestLattice(width: number, height: number): LatticeState {
+  const vertices: Vertex[][] = [];
+  const horizontalEdges: EdgeState[][] = [];
+  const verticalEdges: EdgeState[][] = [];
+
+  // Initialize with a simple pattern (all a1 vertices)
+  for (let row = 0; row < height; row++) {
+    vertices[row] = [];
+    horizontalEdges[row] = [];
+    verticalEdges[row] = [];
+
+    for (let col = 0; col < width; col++) {
+      // Create a1 vertex (in from left & top, out to right & bottom)
+      vertices[row][col] = {
+        position: { row, col },
+        type: VertexType.a1,
+        configuration: getVertexConfiguration(VertexType.a1),
+      };
+
+      // Set horizontal edge (points right, so EdgeState.In)
+      if (col < width - 1) {
+        horizontalEdges[row][col] = EdgeState.In;
+      }
+
+      // Set vertical edge (points down, so EdgeState.In)
+      if (row < height - 1) {
+        verticalEdges[row][col] = EdgeState.In;
+      }
+    }
+  }
+
+  return {
+    width,
+    height,
+    vertices,
+    horizontalEdges,
+    verticalEdges,
+  };
+}
+
+/**
+ * Create a lattice with specific edge patterns for testing
+ */
+function createCustomLattice(
+  width: number,
+  height: number,
+  horizontalPattern: EdgeState,
+  verticalPattern: EdgeState,
+): LatticeState {
+  const vertices: Vertex[][] = [];
+  const horizontalEdges: EdgeState[][] = [];
+  const verticalEdges: EdgeState[][] = [];
+
+  for (let row = 0; row < height; row++) {
+    vertices[row] = [];
+    horizontalEdges[row] = [];
+    verticalEdges[row] = [];
+
+    for (let col = 0; col < width; col++) {
+      // Determine vertex type based on edge pattern
+      let type: VertexType = VertexType.a1;
+      if (horizontalPattern === EdgeState.In && verticalPattern === EdgeState.In) {
+        type = VertexType.a1; // In from left & top
+      } else if (horizontalPattern === EdgeState.Out && verticalPattern === EdgeState.Out) {
+        type = VertexType.a2; // In from right & bottom
+      }
+
+      vertices[row][col] = {
+        position: { row, col },
+        type,
+        configuration: getVertexConfiguration(type),
+      };
+
+      if (col < width - 1) {
+        horizontalEdges[row][col] = horizontalPattern;
+      }
+
+      if (row < height - 1) {
+        verticalEdges[row][col] = verticalPattern;
+      }
+    }
+  }
+
+  return {
+    width,
+    height,
+    vertices,
+    horizontalEdges,
+    verticalEdges,
+  };
+}
+
+describe('Height Function Calculator', () => {
+  describe('calculateHeightFunction', () => {
+    it('should calculate correct heights for a simple lattice', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      expect(heightData.heights).toBeDefined();
+      expect(heightData.heights.length).toBe(3);
+      expect(heightData.heights[0].length).toBe(3);
+
+      // Origin should have height 0
+      expect(heightData.heights[0][0]).toBe(0);
+
+      // Check that heights increase as expected
+      // With all edges pointing right and down (EdgeState.In),
+      // heights should increase along both axes
+      expect(heightData.heights[0][1]).toBeGreaterThanOrEqual(0);
+      expect(heightData.heights[1][0]).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should calculate correct statistics', () => {
+      const lattice = createTestLattice(4, 4);
+      const heightData = calculateHeightFunction(lattice);
+
+      expect(heightData.totalVolume).toBeGreaterThanOrEqual(0);
+      expect(heightData.minHeight).toBeLessThanOrEqual(heightData.maxHeight);
+      expect(heightData.averageHeight).toBe(heightData.totalVolume / 16);
+    });
+
+    it('should handle lattice with all edges pointing out', () => {
+      const lattice = createCustomLattice(3, 3, EdgeState.Out, EdgeState.Out);
+      const heightData = calculateHeightFunction(lattice);
+
+      // When edges point out (left and up), heights increase differently
+      expect(heightData.heights[0][0]).toBe(0);
+
+      // Moving right with EdgeState.Out means edge points left (into next vertex)
+      expect(heightData.heights[0][1]).toBe(1);
+      expect(heightData.heights[0][2]).toBe(2);
+    });
+  });
+
+  describe('getVertexHeightContribution', () => {
+    it('should calculate correct contribution for a1 vertex', () => {
+      const vertex: Vertex = {
+        position: { row: 1, col: 1 },
+        type: VertexType.a1,
+        configuration: getVertexConfiguration(VertexType.a1),
+      };
+
+      const contribution = getVertexHeightContribution(vertex);
+
+      // a1 has In from left and top
+      expect(contribution.fromLeft).toBe(1);
+      expect(contribution.fromTop).toBe(1);
+      expect(contribution.total).toBe(2);
+    });
+
+    it('should calculate correct contribution for b1 vertex', () => {
+      const vertex: Vertex = {
+        position: { row: 1, col: 1 },
+        type: VertexType.b1,
+        configuration: getVertexConfiguration(VertexType.b1),
+      };
+
+      const contribution = getVertexHeightContribution(vertex);
+
+      // b1 has In from left and right, Out to top and bottom
+      expect(contribution.fromLeft).toBe(1);
+      expect(contribution.fromTop).toBe(0);
+      expect(contribution.total).toBe(1);
+    });
+  });
+
+  describe('getHeightDifference', () => {
+    it('should calculate correct height difference', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const diff = getHeightDifference(heightData, { row: 0, col: 0 }, { row: 0, col: 1 });
+
+      expect(diff).toBeDefined();
+      expect(diff).toBe(heightData.heights[0][1] - heightData.heights[0][0]);
+    });
+
+    it('should return null for invalid positions', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const diff = getHeightDifference(heightData, { row: -1, col: 0 }, { row: 0, col: 0 });
+
+      expect(diff).toBeNull();
+    });
+  });
+
+  describe('getHeightProfile', () => {
+    it('should extract row profile correctly', () => {
+      const lattice = createTestLattice(4, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const profile = getHeightProfile(heightData, 'row', 1);
+
+      expect(profile.length).toBe(4);
+      expect(profile).toEqual(heightData.heights[1]);
+    });
+
+    it('should extract column profile correctly', () => {
+      const lattice = createTestLattice(3, 4);
+      const heightData = calculateHeightFunction(lattice);
+
+      const profile = getHeightProfile(heightData, 'column', 1);
+
+      expect(profile.length).toBe(4);
+      expect(profile[0]).toBe(heightData.heights[0][1]);
+      expect(profile[1]).toBe(heightData.heights[1][1]);
+      expect(profile[2]).toBe(heightData.heights[2][1]);
+      expect(profile[3]).toBe(heightData.heights[3][1]);
+    });
+
+    it('should return empty array for invalid index', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const profile = getHeightProfile(heightData, 'row', 10);
+
+      expect(profile).toEqual([]);
+    });
+  });
+
+  describe('calculateHeightGradient', () => {
+    it('should calculate gradient correctly', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const gradient = calculateHeightGradient(heightData);
+
+      expect(gradient.length).toBe(3);
+      expect(gradient[0].length).toBe(3);
+
+      // Each element should have dx and dy
+      expect(gradient[1][1]).toHaveProperty('dx');
+      expect(gradient[1][1]).toHaveProperty('dy');
+    });
+  });
+
+  describe('verifyHeightConsistency', () => {
+    it('should verify consistent height function', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = calculateHeightFunction(lattice);
+
+      const result = verifyHeightConsistency(lattice, heightData);
+
+      // The consistency check allows for some boundary effects
+      expect(result.isConsistent).toBeDefined();
+      expect(result.errors).toBeDefined();
+    });
+
+    it('should detect dimension mismatch', () => {
+      const lattice = createTestLattice(3, 3);
+      const heightData = {
+        heights: [
+          [0, 0],
+          [0, 0],
+        ], // Wrong dimensions
+        totalVolume: 0,
+        minHeight: 0,
+        maxHeight: 0,
+        averageHeight: 0,
+      };
+
+      const result = verifyHeightConsistency(lattice, heightData);
+
+      expect(result.isConsistent).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+      expect(result.errors[0]).toContain('Dimension mismatch');
+    });
+  });
+
+  describe('exportHeightData', () => {
+    it('should export height data correctly', () => {
+      const lattice = createTestLattice(2, 2);
+      const heightData = calculateHeightFunction(lattice);
+
+      const exported = exportHeightData(heightData);
+
+      expect(exported.heights).toEqual(heightData.heights);
+      expect(exported.stats.totalVolume).toBe(heightData.totalVolume);
+      expect(exported.stats.minHeight).toBe(heightData.minHeight);
+      expect(exported.stats.maxHeight).toBe(heightData.maxHeight);
+      expect(exported.stats.averageHeight).toBe(heightData.averageHeight);
+      expect(exported.stats.dimensions.rows).toBe(2);
+      expect(exported.stats.dimensions.cols).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #32 — two 6-vertex simulations (DWBC High vs Low) running side-by-side with **height-based convergence tracking**. This is the **clean core** extracted from the tangled PR #33 (73 files) onto the repaired `main`; the unrelated concerns it bundled are filed separately (see below).

## What's included
- `lib/six-vertex/heightFunction.ts` — height function + statistics. **Derives height from each vertex's `configuration`** (always present) instead of the lattice edge arrays, which the optimized engine leaves empty — that mismatch was crashing the route.
- `lib/six-vertex/dualSimulation.ts` — `DualSimulationManager` running both sims with convergence metrics (removed leftover `console.log`s).
- `routes/dualSimulation.tsx` + `routes/heightDemo.tsx` — the `/dual-simulation` and `/height-demo` routes, wired into `App.tsx` (nav + routing), with a **live convergence readout** (volume ratio, volume/height diffs, converged status).
- `components/DualSimulationDisplay.tsx` (+css) — side-by-side lattice display. **Decoupled from the pan/zoom subsystem** (plain canvases) and given a concrete height (the container was collapsing to ~28px, hiding the canvases).

## Deliberately NOT included (filed as separate issues)
- AWS deployment infrastructure tree → separate issue
- Pan/zoom canvas subsystem → separate issue
- ~15 throwaway debug/centering components (the cause of #33's failing build) → dropped

## Verification
Verified end-to-end in a browser: both simulations render, evolve from DWBC High/Low, and converge (~99% volume ratio → "Converged ✓"). No console errors.
- [x] `npm run build` ✓
- [x] `npm run typecheck` ✓
- [x] `npx eslint .` → 0 errors
- [x] Full suite: 21 suites / 282 tests pass (incl. 14 height-function tests)

Supersedes #33. Fixes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)