### PR TITLE
refactor(ui): consolidate design system, unify vertex palette, fix theming & a11y

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -20,8 +20,8 @@
 
 /* Dark mode specific header styling */
 [data-theme='dark'] .app-header {
-  background: linear-gradient(135deg, #1f2937 0%, #374151 100%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(135deg, var(--color-bg-tertiary) 0%, var(--color-bg-quaternary) 100%);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .header-content {
@@ -57,13 +57,9 @@
   color: var(--color-text-primary);
 }
 
-[data-theme='dark'] .app-header h1 {
-  color: white;
-}
-
 .header-info {
   font-size: 0.875rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--color-text-secondary);
   font-style: italic;
 }
 
@@ -88,15 +84,6 @@
   text-decoration: none;
 }
 
-[data-theme='dark'] .header-nav a {
-  color: rgba(255, 255, 255, 0.9);
-}
-
-[data-theme='dark'] .header-nav a:hover {
-  background-color: rgba(255, 255, 255, 0.1);
-  color: white;
-}
-
 /* Main Content - Using CSS Grid for equal-height columns */
 .main-content {
   display: grid;
@@ -115,6 +102,37 @@
 .panel-section {
   height: 100%;
   align-self: stretch;
+}
+
+/* Dismissible in-UI notice banner (replaces blocking alert() dialogs).
+   Spans the full width of the simulator's 3-column grid. */
+.simulator-alert {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+}
+
+.simulator-alert__message {
+  flex: 1;
+}
+
+.simulator-alert__dismiss {
+  flex: 0 0 auto;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: var(--font-size-xl);
+  line-height: 1;
+  padding: 0;
+  cursor: pointer;
+  opacity: 0.7;
+  transition: opacity var(--transition-fast);
+}
+
+.simulator-alert__dismiss:hover {
+  opacity: 1;
 }
 
 /* Animations */
@@ -196,7 +214,7 @@
 button:focus-visible,
 input:focus-visible,
 select:focus-visible {
-  outline: 2px solid #3b82f6;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 

--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -31,6 +31,7 @@ function MainSimulator() {
 
   // Simulation state
   const [isRunning, setIsRunning] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [stats, setStats] = useState<SimulationStats | null>(null);
   const [latticeState, setLatticeState] = useState<LatticeState | null>(null);
   const [latticeSize, setLatticeSize] = useState(10);
@@ -132,7 +133,7 @@ function MainSimulator() {
     } catch (error) {
       console.error('Failed to initialize simulation:', error);
       // Show error in UI instead of crashing
-      alert(`Failed to initialize simulation: ${error}`);
+      setErrorMessage(`Failed to initialize simulation: ${error}`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [latticeSize, temperature, boundaryCondition, dwbcType, seed]);
@@ -193,7 +194,7 @@ function MainSimulator() {
       }
     } catch (error) {
       console.error('Error during step:', error);
-      alert(`Error during step: ${error}`);
+      setErrorMessage(`Error during step: ${error}`);
     }
   }, []);
 
@@ -351,7 +352,7 @@ function MainSimulator() {
         console.log('Simulation loaded successfully');
       } catch (error) {
         console.error('Failed to load simulation data:', error);
-        alert('Failed to load simulation. Please check the console for details.');
+        setErrorMessage('Failed to load simulation. Please check the console for details.');
       }
     },
     [isRunning, handlePause],
@@ -376,6 +377,19 @@ function MainSimulator() {
 
   return (
     <div className="main-content">
+      {errorMessage && (
+        <div className="alert alert--danger simulator-alert" role="alert">
+          <span className="simulator-alert__message">{errorMessage}</span>
+          <button
+            type="button"
+            className="simulator-alert__dismiss"
+            aria-label="Dismiss notification"
+            onClick={() => setErrorMessage(null)}
+          >
+            &times;
+          </button>
+        </div>
+      )}
       <CollapsiblePanel title="Controls" side="left" className="panel-section">
         <ControlPanel
           isRunning={isRunning}
@@ -409,7 +423,7 @@ function MainSimulator() {
                 if (simulationRef.current) {
                   setIsRunning(true);
                 } else {
-                  alert('Failed to initialize simulation. Please try resetting.');
+                  setErrorMessage('Failed to initialize simulation. Please try resetting.');
                 }
               }, 100);
             } else {

--- a/client/src/components/ControlPanel.css
+++ b/client/src/components/ControlPanel.css
@@ -91,35 +91,36 @@
 }
 
 .control-button.primary {
-  background: #3b82f6;
-  color: white;
-  border-color: #3b82f6;
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
+  border-color: var(--color-primary);
 }
 
 .control-button.primary:hover:not(:disabled) {
-  background: #2563eb;
-  border-color: #2563eb;
+  background: var(--color-primary-hover);
+  border-color: var(--color-primary-hover);
 }
 
 .control-button.warning {
-  background: #f59e0b;
-  color: white;
-  border-color: #f59e0b;
+  background: var(--color-warning);
+  color: var(--color-text-inverse);
+  border-color: var(--color-warning);
 }
 
 .control-button.warning:hover:not(:disabled) {
-  background: #d97706;
-  border-color: #d97706;
+  background: var(--color-warning);
+  filter: brightness(0.92);
+  border-color: var(--color-warning);
 }
 
 .control-button.secondary {
-  background: var(--color-bg-secondary, white);
-  color: #3b82f6;
-  border: 2px solid #3b82f6;
+  background: var(--color-bg-secondary);
+  color: var(--color-primary);
+  border: 2px solid var(--color-primary);
 }
 
 .control-button.secondary:hover:not(:disabled) {
-  background: #eff6ff;
+  background: var(--color-primary-light);
 }
 
 .control-button.full-width {
@@ -173,27 +174,27 @@
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: #3b82f6;
+  background: var(--color-primary);
   cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-  transition: all 0.15s ease;
+  border: 2px solid var(--color-bg-primary);
+  box-shadow: var(--shadow-sm);
+  transition: all var(--transition-fast);
 }
 
 .slider::-webkit-slider-thumb:hover {
   transform: scale(1.1);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--shadow-md);
 }
 
 .slider::-moz-range-thumb {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: #3b82f6;
+  background: var(--color-primary);
   cursor: pointer;
-  border: 2px solid white;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
-  transition: all 0.15s ease;
+  border: 2px solid var(--color-bg-primary);
+  box-shadow: var(--shadow-sm);
+  transition: all var(--transition-fast);
 }
 
 .slider.small {
@@ -211,14 +212,46 @@
 }
 
 .value-display {
+  display: inline-block;
   min-width: 3rem;
   text-align: center;
-  padding: 0.25rem 0.5rem;
-  background: var(--color-bg-tertiary, #e5e7eb);
-  border-radius: 6px;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--color-text-primary, #111827);
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-bg-tertiary);
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.legend-toggle {
+  width: 100%;
+  padding: var(--spacing-sm);
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: var(--font-size-sm);
+  font-family: inherit;
+  transition: background var(--transition-fast);
+}
+
+.legend-toggle:hover {
+  background: var(--color-bg-hover);
+}
+
+.legend-content {
+  margin-top: var(--spacing-sm);
+}
+
+.legend-caption {
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  font-style: italic;
 }
 
 .select-input,
@@ -235,8 +268,8 @@
 .select-input:focus,
 .number-input:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-primary) 15%, transparent);
 }
 
 .radio-group {

--- a/client/src/components/ControlPanel.tsx
+++ b/client/src/components/ControlPanel.tsx
@@ -1,5 +1,8 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { BoundaryCondition, RenderMode } from '../lib/six-vertex/types';
+import type { VertexType } from '../lib/six-vertex/types';
+import { getCurrentVertexColors } from '../lib/six-vertex/themeColors';
+import { useTheme } from '../hooks/useTheme';
 import { VertexLegend } from './VertexEdgeVisualization';
 import './ControlPanel.css';
 
@@ -77,15 +80,15 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
   onExportImage,
 }) => {
   const [showLegend, setShowLegend] = useState(false);
+  const { theme } = useTheme();
 
-  const vertexColors = {
-    a1: '#3B82F6', // blue
-    a2: '#60A5FA', // light blue
-    b1: '#10B981', // green
-    b2: '#34D399', // light green
-    c1: '#F59E0B', // orange
-    c2: '#FCD34D', // light orange
-  };
+  // Single source of truth: the canonical theme-aware vertex palette shared
+  // with the Canvas renderer and the StatisticsPanel legend. Recomputed when
+  // the active theme changes so the weight swatches match the canvas exactly.
+  // `theme` is the intentional recompute trigger (getCurrentVertexColors reads
+  // the active data-theme from the DOM, which `theme` keeps in sync).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const vertexColors = useMemo(() => getCurrentVertexColors(), [theme]);
 
   return (
     <div className="control-panel">
@@ -170,8 +173,12 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                 max={3}
                 step={0.1}
                 className="slider"
+                aria-label="Speed (steps per frame)"
+                aria-valuetext={`${Math.round(stepsPerFrame)} steps per frame`}
               />
-              <span className="value-display">{Math.round(stepsPerFrame)}</span>
+              <output className="value-display" aria-live="polite">
+                {Math.round(stepsPerFrame)}
+              </output>
             </div>
           </label>
         </div>
@@ -203,8 +210,12 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                 max={100}
                 step={1}
                 className="slider"
+                aria-label="Lattice size (N by N)"
+                aria-valuetext={`${latticeSize} by ${latticeSize}`}
               />
-              <span className="value-display">{latticeSize}</span>
+              <output className="value-display" aria-live="polite">
+                {latticeSize}
+              </output>
             </div>
           </label>
         </div>
@@ -291,74 +302,63 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
                 max={10}
                 step={0.1}
                 className="slider"
+                aria-label="Temperature (T)"
+                aria-valuetext={temperature.toFixed(1)}
               />
-              <span className="value-display">{temperature.toFixed(1)}</span>
+              <output className="value-display" aria-live="polite">
+                {temperature.toFixed(1)}
+              </output>
             </div>
           </label>
         </div>
 
         <div className="weights-grid">
           <h4>Vertex Weights</h4>
-          {Object.entries(weights).map(([type, weight]) => (
-            <div key={type} className="weight-control">
-              <div className="weight-header">
-                <span
-                  className="weight-label"
-                  style={{ color: vertexColors[type as keyof typeof vertexColors] }}
-                >
-                  {type}
-                </span>
-                <span className="weight-value">{weight.toFixed(2)}</span>
+          {Object.entries(weights).map(([type, weight]) => {
+            const color = vertexColors[type as VertexType] ?? 'var(--color-text-muted)';
+            const fillPercent = ((weight - 0.1) / 4.9) * 100;
+            return (
+              <div key={type} className="weight-control">
+                <div className="weight-header">
+                  <span className="weight-label" style={{ color }}>
+                    {type}
+                  </span>
+                  <span className="weight-value">{weight.toFixed(2)}</span>
+                </div>
+                <input
+                  type="range"
+                  value={weight}
+                  onChange={(e) => onWeightChange(type, parseFloat(e.target.value))}
+                  min={0.1}
+                  max={5}
+                  step={0.1}
+                  className="slider small"
+                  aria-label={`Weight ${type}`}
+                  aria-valuetext={weight.toFixed(2)}
+                  style={{
+                    background: `linear-gradient(to right, color-mix(in srgb, ${color} 25%, transparent) 0%, ${color} ${fillPercent}%, var(--color-bg-tertiary) ${fillPercent}%, var(--color-bg-tertiary) 100%)`,
+                  }}
+                />
               </div>
-              <input
-                type="range"
-                value={weight}
-                onChange={(e) => onWeightChange(type, parseFloat(e.target.value))}
-                min={0.1}
-                max={5}
-                step={0.1}
-                className="slider small"
-                style={{
-                  background: `linear-gradient(to right, ${vertexColors[type as keyof typeof vertexColors]}40 0%, ${vertexColors[type as keyof typeof vertexColors]} ${((weight - 0.1) / 4.9) * 100}%, #e5e7eb ${((weight - 0.1) / 4.9) * 100}%, #e5e7eb 100%)`,
-                }}
-              />
-            </div>
-          ))}
+            );
+          })}
         </div>
 
         {/* Vertex Edge Pattern Legend */}
         <div className="control-item">
           <button
+            type="button"
             className="legend-toggle"
             onClick={() => setShowLegend(!showLegend)}
-            style={{
-              width: '100%',
-              padding: '8px',
-              background: '#f3f4f6',
-              border: '1px solid #e5e7eb',
-              borderRadius: '4px',
-              cursor: 'pointer',
-              display: 'flex',
-              justifyContent: 'space-between',
-              alignItems: 'center',
-            }}
+            aria-expanded={showLegend}
           >
             <span>Vertex Edge Patterns</span>
-            <span>{showLegend ? '▼' : '▶'}</span>
+            <span aria-hidden="true">{showLegend ? '▼' : '▶'}</span>
           </button>
           {showLegend && (
-            <div style={{ marginTop: '10px' }}>
+            <div className="legend-content">
               <VertexLegend showArrows={false} />
-              <div
-                style={{
-                  marginTop: '8px',
-                  fontSize: '0.85rem',
-                  color: '#6b7280',
-                  fontStyle: 'italic',
-                }}
-              >
-                Bold edges show the connected path segments
-              </div>
+              <div className="legend-caption">Bold edges show the connected path segments</div>
             </div>
           )}
         </div>

--- a/client/src/components/ErrorBoundary.tsx
+++ b/client/src/components/ErrorBoundary.tsx
@@ -42,102 +42,64 @@ class ErrorBoundary extends Component<Props, State> {
         return this.props.fallback;
       }
 
+      const preStyle: React.CSSProperties = {
+        backgroundColor: 'var(--color-bg-primary)',
+        color: 'var(--color-text-primary)',
+        padding: 'var(--spacing-sm)',
+        borderRadius: 'var(--border-radius-sm)',
+        border: '1px solid var(--color-border)',
+        overflow: 'auto',
+        maxHeight: '200px',
+        fontSize: 'var(--font-size-xs)',
+      };
+
       return (
         <div
+          className="alert alert--danger"
+          role="alert"
           style={{
-            padding: '20px',
-            margin: '20px',
-            border: '2px solid #ff6b6b',
-            borderRadius: '8px',
-            backgroundColor: '#ffe0e0',
-            color: '#333',
-            fontFamily: 'monospace',
+            margin: 'var(--spacing-lg)',
+            fontFamily: 'var(--font-family-mono, monospace)',
+            // Keep readable in dark mode: .alert--danger hard-codes a dark-red
+            // text color that fails contrast on the dark-mode danger background.
+            color: 'var(--color-text-primary)',
           }}
         >
-          <h2 style={{ color: '#d32f2f' }}>⚠️ Something went wrong</h2>
-          <details style={{ marginTop: '10px' }}>
-            <summary style={{ cursor: 'pointer', fontWeight: 'bold' }}>
+          <h2 style={{ marginTop: 0 }}>⚠️ Something went wrong</h2>
+          <details style={{ marginTop: 'var(--spacing-sm)' }}>
+            <summary style={{ cursor: 'pointer', fontWeight: 'var(--font-weight-bold)' }}>
               Error Details (click to expand)
             </summary>
-            <div style={{ marginTop: '10px' }}>
+            <div style={{ marginTop: 'var(--spacing-sm)' }}>
               <h3>Error:</h3>
-              <pre
-                style={{
-                  backgroundColor: '#fff',
-                  padding: '10px',
-                  borderRadius: '4px',
-                  overflow: 'auto',
-                  maxHeight: '200px',
-                }}
-              >
-                {this.state.error && this.state.error.toString()}
-              </pre>
+              <pre style={preStyle}>{this.state.error && this.state.error.toString()}</pre>
 
               {this.state.errorInfo && (
                 <>
                   <h3>Component Stack:</h3>
-                  <pre
-                    style={{
-                      backgroundColor: '#fff',
-                      padding: '10px',
-                      borderRadius: '4px',
-                      overflow: 'auto',
-                      maxHeight: '200px',
-                      fontSize: '12px',
-                    }}
-                  >
-                    {this.state.errorInfo.componentStack}
-                  </pre>
+                  <pre style={preStyle}>{this.state.errorInfo.componentStack}</pre>
                 </>
               )}
 
               {this.state.error?.stack && (
                 <>
                   <h3>Stack Trace:</h3>
-                  <pre
-                    style={{
-                      backgroundColor: '#fff',
-                      padding: '10px',
-                      borderRadius: '4px',
-                      overflow: 'auto',
-                      maxHeight: '200px',
-                      fontSize: '12px',
-                    }}
-                  >
-                    {this.state.error.stack}
-                  </pre>
+                  <pre style={preStyle}>{this.state.error.stack}</pre>
                 </>
               )}
             </div>
           </details>
 
-          <div style={{ marginTop: '20px' }}>
-            <button
-              onClick={this.handleReset}
-              style={{
-                padding: '10px 20px',
-                fontSize: '14px',
-                backgroundColor: '#4CAF50',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-                marginRight: '10px',
-              }}
-            >
+          <div
+            style={{ marginTop: 'var(--spacing-lg)', display: 'flex', gap: 'var(--spacing-sm)' }}
+          >
+            <button type="button" className="btn btn--success" onClick={this.handleReset}>
               Try Again
             </button>
             <button
+              type="button"
+              className="btn btn--primary"
               onClick={() => window.location.reload()}
-              style={{
-                padding: '10px 20px',
-                fontSize: '14px',
-                backgroundColor: '#2196F3',
-                color: 'white',
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
             >
               Reload Page
             </button>

--- a/client/src/components/StatisticsPanel.tsx
+++ b/client/src/components/StatisticsPanel.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useMemo } from 'react';
 import type { SimulationStats } from '../lib/six-vertex/types';
 import { VertexType } from '../lib/six-vertex/types';
+import { getCurrentVertexColors } from '../lib/six-vertex/themeColors';
+import { useTheme } from '../hooks/useTheme';
 import './StatisticsPanel.css';
 
 interface StatisticsPanelProps {
@@ -10,18 +12,15 @@ interface StatisticsPanelProps {
 
 const StatisticsPanel: React.FC<StatisticsPanelProps> = ({ stats, fps }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const { theme } = useTheme();
 
-  const vertexColors = useMemo(
-    () => ({
-      [VertexType.a1]: '#3B82F6',
-      [VertexType.a2]: '#60A5FA',
-      [VertexType.b1]: '#10B981',
-      [VertexType.b2]: '#34D399',
-      [VertexType.c1]: '#F59E0B',
-      [VertexType.c2]: '#FCD34D',
-    }),
-    [],
-  );
+  // Single source of truth: the canonical theme-aware vertex palette shared
+  // with the Canvas renderer. Recomputed when the active theme changes so the
+  // legend swatches and chart bars always match the canvas exactly.
+  // `theme` is the intentional recompute trigger (getCurrentVertexColors reads
+  // the active data-theme from the DOM, which `theme` keeps in sync).
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const vertexColors = useMemo(() => getCurrentVertexColors(), [theme]);
 
   // Draw vertex distribution chart
   useEffect(() => {
@@ -31,6 +30,15 @@ const StatisticsPanel: React.FC<StatisticsPanelProps> = ({ stats, fps }) => {
       const canvas = canvasRef.current;
       const ctx = canvas.getContext('2d');
       if (!ctx) return;
+
+      // Resolve themed colors from the design tokens so the chart text/axes
+      // adapt to light/dark mode (canvas cannot consume CSS vars directly).
+      const rootStyle = getComputedStyle(document.documentElement);
+      const token = (name: string, fallback: string) =>
+        rootStyle.getPropertyValue(name).trim() || fallback;
+      const labelColor = token('--color-text-primary', '#374151');
+      const mutedColor = token('--color-text-secondary', '#6b7280');
+      const axisColor = token('--color-border', '#e5e7eb');
 
       // Set canvas size
       const rect = canvas.getBoundingClientRect();
@@ -72,23 +80,23 @@ const StatisticsPanel: React.FC<StatisticsPanelProps> = ({ stats, fps }) => {
         const y = rect.height - 20 - barHeight;
 
         // Draw bar
-        ctx.fillStyle = vertexColors[type as VertexType] || '#999999';
+        ctx.fillStyle = vertexColors[type as VertexType] || mutedColor;
         ctx.fillRect(x + barWidth * 0.1, y, barWidth * 0.8, barHeight);
 
         // Draw label
-        ctx.fillStyle = '#374151';
+        ctx.fillStyle = labelColor;
         ctx.font = '11px system-ui';
         ctx.textAlign = 'center';
         ctx.fillText(type, x + barWidth / 2, rect.height - 5);
 
         // Draw percentage
-        ctx.fillStyle = '#6b7280';
+        ctx.fillStyle = mutedColor;
         ctx.font = '10px system-ui';
         ctx.fillText(`${(percentage * 100).toFixed(1)}%`, x + barWidth / 2, y - 5);
       });
 
       // Draw axes
-      ctx.strokeStyle = '#e5e7eb';
+      ctx.strokeStyle = axisColor;
       ctx.lineWidth = 1;
       ctx.beginPath();
       ctx.moveTo(25, 10);
@@ -188,7 +196,10 @@ const StatisticsPanel: React.FC<StatisticsPanelProps> = ({ stats, fps }) => {
                 <div key={type} className="legend-item">
                   <span
                     className="legend-color"
-                    style={{ backgroundColor: vertexColors[type as VertexType] || '#999999' }}
+                    style={{
+                      backgroundColor:
+                        vertexColors[type as VertexType] || 'var(--color-text-muted)',
+                    }}
                   />
                   <span className="legend-label">{type}</span>
                   <span className="legend-value">{count || 0}</span>

--- a/client/src/components/VertexEdgeVisualization.tsx
+++ b/client/src/components/VertexEdgeVisualization.tsx
@@ -5,6 +5,8 @@
 
 import React from 'react';
 import { VertexType } from '../lib/six-vertex/types';
+import { getCurrentVertexColors } from '../lib/six-vertex/themeColors';
+import { useTheme } from '../hooks/useTheme';
 
 interface VertexEdgeVisualizationProps {
   vertexType: VertexType;
@@ -28,6 +30,10 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
   showArrows = false,
   showLabel = false,
 }) => {
+  // Subscribe to the theme so the diagram (and its vertex palette) re-renders
+  // when light/dark mode toggles.
+  useTheme();
+
   const strokeWidth = 2;
   const boldStrokeWidth = 5;
   const arrowSize = 8;
@@ -71,7 +77,7 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
           ${tipX - Math.cos(baseAngle1) * arrowSize},${tipY - Math.sin(baseAngle1) * arrowSize}
           ${tipX - Math.cos(baseAngle2) * arrowSize},${tipY - Math.sin(baseAngle2) * arrowSize}
         `}
-        fill="#333"
+        fill="var(--color-text-primary)"
       />
     );
   };
@@ -105,19 +111,17 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
 
   const boldEdges = getBoldEdges();
 
-  // Vertex type colors
-  const vertexColors = {
-    [VertexType.a1]: '#ff6b6b',
-    [VertexType.a2]: '#4ecdc4',
-    [VertexType.b1]: '#45b7d1',
-    [VertexType.b2]: '#96ceb4',
-    [VertexType.c1]: '#ffd93d',
-    [VertexType.c2]: '#c9a0ff',
-  };
+  // Canonical, theme-aware vertex palette shared with the Canvas renderer and
+  // the ControlPanel/StatisticsPanel legends (single source of truth).
+  const vertexColors = getCurrentVertexColors();
+
+  // Theme tokens for the diagram chrome (bold/thin edges, center point, border).
+  const boldEdgeColor = 'var(--color-text-primary)';
+  const thinEdgeColor = 'var(--color-text-muted)';
 
   return (
-    <div style={{ display: 'inline-block', margin: '5px' }}>
-      <svg width={size} height={size} style={{ border: '1px solid #ddd' }}>
+    <div style={{ display: 'inline-block', margin: 'var(--spacing-xs)' }}>
+      <svg width={size} height={size} style={{ border: '1px solid var(--color-border)' }}>
         {/* Background */}
         <rect
           x={0}
@@ -129,7 +133,7 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
         />
 
         {/* Center vertex point */}
-        <circle cx={center} cy={center} r={4} fill="#333" />
+        <circle cx={center} cy={center} r={4} fill={boldEdgeColor} />
 
         {/* Left edge */}
         <line
@@ -137,7 +141,7 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
           y1={center}
           x2={center - 4}
           y2={center}
-          stroke={boldEdges.left ? '#333' : '#999'}
+          stroke={boldEdges.left ? boldEdgeColor : thinEdgeColor}
           strokeWidth={boldEdges.left ? boldStrokeWidth : strokeWidth}
           strokeLinecap="round"
         />
@@ -149,7 +153,7 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
           y1={center}
           x2={size - padding}
           y2={center}
-          stroke={boldEdges.right ? '#333' : '#999'}
+          stroke={boldEdges.right ? boldEdgeColor : thinEdgeColor}
           strokeWidth={boldEdges.right ? boldStrokeWidth : strokeWidth}
           strokeLinecap="round"
         />
@@ -161,7 +165,7 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
           y1={padding}
           x2={center}
           y2={center - 4}
-          stroke={boldEdges.top ? '#333' : '#999'}
+          stroke={boldEdges.top ? boldEdgeColor : thinEdgeColor}
           strokeWidth={boldEdges.top ? boldStrokeWidth : strokeWidth}
           strokeLinecap="round"
         />
@@ -173,14 +177,23 @@ export const VertexEdgeVisualization: React.FC<VertexEdgeVisualizationProps> = (
           y1={center + 4}
           x2={center}
           y2={size - padding}
-          stroke={boldEdges.bottom ? '#333' : '#999'}
+          stroke={boldEdges.bottom ? boldEdgeColor : thinEdgeColor}
           strokeWidth={boldEdges.bottom ? boldStrokeWidth : strokeWidth}
           strokeLinecap="round"
         />
         {renderArrow(center, center, center, size - padding, config.bottom)}
       </svg>
       {showLabel && (
-        <div style={{ textAlign: 'center', fontSize: '12px', marginTop: '2px' }}>{vertexType}</div>
+        <div
+          style={{
+            textAlign: 'center',
+            fontSize: 'var(--font-size-xs)',
+            color: 'var(--color-text-primary)',
+            marginTop: '2px',
+          }}
+        >
+          {vertexType}
+        </div>
       )}
     </div>
   );

--- a/client/src/components/VisualizationCanvas.css
+++ b/client/src/components/VisualizationCanvas.css
@@ -15,18 +15,8 @@
   flex: 1;
   position: relative;
   overflow: hidden;
+  /* Flat background so the scientific figure reads cleanly (no checkerboard). */
   background-color: var(--color-bg-secondary);
-  background-image:
-    linear-gradient(45deg, var(--color-bg-tertiary) 25%, transparent 25%),
-    linear-gradient(-45deg, var(--color-bg-tertiary) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, var(--color-bg-tertiary) 75%),
-    linear-gradient(-45deg, transparent 75%, var(--color-bg-tertiary) 75%);
-  background-size: 20px 20px;
-  background-position:
-    0 0,
-    0 10px,
-    10px -10px,
-    -10px 0px;
   transition: background var(--transition-base);
 }
 

--- a/client/src/components/VisualizationCanvas.tsx
+++ b/client/src/components/VisualizationCanvas.tsx
@@ -133,6 +133,17 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
     }
   }, [handleWheel]);
 
+  // Auto-fit the lattice on initial mount and whenever the lattice size (N) changes,
+  // so it never sits tiny in a large canvas. The manual "Fit to Screen" button remains.
+  const latticeSize = latticeState ? `${latticeState.width}x${latticeState.height}` : null;
+  useEffect(() => {
+    if (!latticeSize) return;
+    // Defer to the next frame so the container has its measured size and the
+    // renderer has drawn the current lattice before we compute the fit scale.
+    const id = requestAnimationFrame(() => handleFitToScreen());
+    return () => cancelAnimationFrame(id);
+  }, [latticeSize, handleFitToScreen]);
+
   return (
     <div className="visualization-container" ref={containerRef}>
       <div className="canvas-wrapper">

--- a/client/src/lib/six-vertex/themeColors.ts
+++ b/client/src/lib/six-vertex/themeColors.ts
@@ -1,52 +1,79 @@
 /**
- * Get theme-aware colors for the canvas renderer
+ * Theme-aware colors for the renderer and the DOM legends.
+ *
+ * This file is the SINGLE source of truth for the six vertex-type colors so the
+ * Canvas and the React legends (ControlPanel, StatisticsPanel, flipDebug) never
+ * disagree. The palette is based on the Okabe–Ito colour-vision-deficiency-safe
+ * qualitative palette so the six types stay distinguishable for colour-blind users.
  */
 
 import { VertexType } from './types';
 
+export type VertexColorMap = Record<VertexType, string>;
+
+/** Okabe–Ito based, tuned for legibility on a white background. */
+const VERTEX_COLORS_LIGHT: VertexColorMap = {
+  [VertexType.a1]: '#d55e00', // vermillion
+  [VertexType.a2]: '#e69f00', // orange
+  [VertexType.b1]: '#0072b2', // blue
+  [VertexType.b2]: '#56b4e9', // sky blue
+  [VertexType.c1]: '#009e73', // bluish green
+  [VertexType.c2]: '#cc79a7', // reddish purple
+};
+
+/** Same hues, brightened slightly for contrast on the dark background. */
+const VERTEX_COLORS_DARK: VertexColorMap = {
+  [VertexType.a1]: '#ff7d3b',
+  [VertexType.a2]: '#ffbf47',
+  [VertexType.b1]: '#4da3ff',
+  [VertexType.b2]: '#8fd0f5',
+  [VertexType.c1]: '#3ad4a8',
+  [VertexType.c2]: '#e89cc4',
+};
+
+/** The canonical vertex-color map for the given theme. */
+export function getVertexColors(isDark: boolean): VertexColorMap {
+  return isDark ? VERTEX_COLORS_DARK : VERTEX_COLORS_LIGHT;
+}
+
+/** True when the dark theme is currently active on the document. */
+export function isDarkTheme(): boolean {
+  return (
+    typeof document !== 'undefined' &&
+    document.documentElement.getAttribute('data-theme') === 'dark'
+  );
+}
+
+/** Vertex colors for the currently-active theme (for DOM legends). */
+export function getCurrentVertexColors(): VertexColorMap {
+  return getVertexColors(isDarkTheme());
+}
+
+/**
+ * Get theme-aware colors for the canvas renderer.
+ */
 export function getThemeColors(isDark: boolean) {
   if (isDark) {
-    // Dark theme colors
     return {
       background: '#1a1a1a',
       grid: '#404040',
       pathSegment: '#e0e0e0',
       arrow: '#4da3ff',
-      vertexTypes: {
-        [VertexType.a1]: '#ff6b6b',
-        [VertexType.a2]: '#51cf66',
-        [VertexType.b1]: '#4da3ff',
-        [VertexType.b2]: '#ffd43b',
-        [VertexType.c1]: '#ff6fff',
-        [VertexType.c2]: '#4dd4ff',
-      },
-    };
-  } else {
-    // Light theme colors (original)
-    return {
-      background: '#ffffff',
-      grid: '#e0e0e0',
-      pathSegment: '#000000',
-      arrow: '#4444ff',
-      vertexTypes: {
-        [VertexType.a1]: '#ff4444',
-        [VertexType.a2]: '#44ff44',
-        [VertexType.b1]: '#4444ff',
-        [VertexType.b2]: '#ffff44',
-        [VertexType.c1]: '#ff44ff',
-        [VertexType.c2]: '#44ffff',
-      },
+      vertexTypes: getVertexColors(true),
     };
   }
+  return {
+    background: '#ffffff',
+    grid: '#e0e0e0',
+    pathSegment: '#000000',
+    arrow: '#4444ff',
+    vertexTypes: getVertexColors(false),
+  };
 }
 
 /**
- * Get colors from CSS variables
+ * Get colors from the active theme (kept for backwards compatibility).
  */
 export function getThemeColorsFromCSS() {
-  // Detect if dark theme is active
-  const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-
-  // Use predefined colors for consistency with the canvas
-  return getThemeColors(isDark);
+  return getThemeColors(isDarkTheme());
 }

--- a/client/src/routes/dualSimulation.module.css
+++ b/client/src/routes/dualSimulation.module.css
@@ -1,0 +1,65 @@
+/* Dual-simulation route styling. Token-based so light/dark themes work for free. */
+
+.page {
+  padding: var(--spacing-xl);
+}
+
+.panel {
+  background: var(--panel-bg);
+  padding: var(--spacing-xl);
+  border-radius: var(--border-radius-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
+.controlsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.weightsSection {
+  margin-top: var(--spacing-xl);
+}
+
+.weightsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-sm);
+}
+
+.actionButtons {
+  margin-top: var(--spacing-xl);
+  display: flex;
+  gap: var(--spacing-sm);
+}
+
+.convergencePanel {
+  margin-top: var(--spacing-xl);
+  padding: var(--spacing-md) var(--spacing-xl);
+  background: var(--panel-bg);
+  border-radius: var(--border-radius-lg);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.metricLabel {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.metricValue {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+}
+
+.statusValue {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-secondary);
+}
+
+.statusConverged {
+  color: var(--color-success);
+}

--- a/client/src/routes/dualSimulation.tsx
+++ b/client/src/routes/dualSimulation.tsx
@@ -4,6 +4,7 @@ import { DualSimulationDisplay } from '../components/DualSimulationDisplay';
 import type { DualSimulationConfig, ConvergenceMetrics } from '../lib/six-vertex/dualSimulation';
 import type { LatticeState } from '../lib/six-vertex/types';
 import '../App.css';
+import styles from './dualSimulation.module.css';
 
 export function DualSimulation() {
   const [size, setSize] = useState(16);
@@ -134,26 +135,11 @@ export function DualSimulation() {
   const cellSize = Math.min(20, 400 / size);
 
   return (
-    <div className="dual-simulation-page" style={{ padding: '20px' }}>
+    <div className={`dual-simulation-page ${styles.page}`}>
       <h1>Dual Simulation with Convergence Tracking</h1>
 
-      <div
-        className="control-panel"
-        style={{
-          background: 'var(--panel-bg)',
-          padding: '20px',
-          borderRadius: '8px',
-          marginBottom: '20px',
-        }}
-      >
-        <div
-          className="controls-grid"
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
-            gap: '15px',
-          }}
-        >
+      <div className={`control-panel ${styles.panel}`}>
+        <div className={`controls-grid ${styles.controlsGrid}`}>
           {/* Size control */}
           <div className="control-group">
             <label>
@@ -213,16 +199,9 @@ export function DualSimulation() {
         </div>
 
         {/* Weight controls */}
-        <div className="weights-section" style={{ marginTop: '20px' }}>
+        <div className={`weights-section ${styles.weightsSection}`}>
           <h3>Vertex Weights</h3>
-          <div
-            className="weights-grid"
-            style={{
-              display: 'grid',
-              gridTemplateColumns: 'repeat(3, 1fr)',
-              gap: '10px',
-            }}
-          >
+          <div className={`weights-grid ${styles.weightsGrid}`}>
             {Object.entries(weights).map(([type, value]) => (
               <label key={type}>
                 {type.toUpperCase()}: {value.toFixed(1)}
@@ -242,54 +221,24 @@ export function DualSimulation() {
         </div>
 
         {/* Action buttons */}
-        <div
-          className="action-buttons"
-          style={{
-            marginTop: '20px',
-            display: 'flex',
-            gap: '10px',
-          }}
-        >
+        <div className={`action-buttons ${styles.actionButtons}`}>
           <button
+            type="button"
             onClick={() => setIsRunning(!isRunning)}
-            style={{
-              padding: '10px 20px',
-              background: isRunning ? 'var(--red-500)' : 'var(--green-500)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-            }}
+            className={`btn ${isRunning ? 'btn--danger' : 'btn--success'}`}
           >
             {isRunning ? 'Stop' : 'Start'}
           </button>
 
-          <button
-            onClick={handleReset}
-            style={{
-              padding: '10px 20px',
-              background: 'var(--blue-500)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-            }}
-          >
+          <button type="button" onClick={handleReset} className="btn btn--primary">
             Reset
           </button>
 
           <button
+            type="button"
             onClick={handleSwapConfigs}
             disabled={isRunning}
-            style={{
-              padding: '10px 20px',
-              background: 'var(--purple-500)',
-              color: 'white',
-              border: 'none',
-              borderRadius: '6px',
-              cursor: 'pointer',
-              opacity: isRunning ? 0.5 : 1,
-            }}
+            className="btn btn--secondary"
           >
             Swap Configs
           </button>
@@ -306,53 +255,27 @@ export function DualSimulation() {
 
       {/* Live convergence metrics */}
       {metrics && (
-        <div
-          className="convergence-panel"
-          style={{
-            marginTop: '20px',
-            padding: '16px 20px',
-            background: 'var(--panel-bg)',
-            borderRadius: '8px',
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-            gap: '12px',
-            alignItems: 'center',
-          }}
-        >
+        <div className={`convergence-panel ${styles.convergencePanel}`}>
           <div>
-            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Convergence</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
-              {(metrics.volumeRatio * 100).toFixed(1)}%
-            </div>
+            <div className={styles.metricLabel}>Convergence</div>
+            <div className={styles.metricValue}>{(metrics.volumeRatio * 100).toFixed(1)}%</div>
           </div>
           <div>
-            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Volume difference</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
-              {metrics.volumeDifference.toFixed(1)}
-            </div>
+            <div className={styles.metricLabel}>Volume difference</div>
+            <div className={styles.metricValue}>{metrics.volumeDifference.toFixed(1)}</div>
           </div>
           <div>
-            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Avg height diff</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
-              {metrics.averageHeightDifference.toFixed(3)}
-            </div>
+            <div className={styles.metricLabel}>Avg height diff</div>
+            <div className={styles.metricValue}>{metrics.averageHeightDifference.toFixed(3)}</div>
           </div>
           <div>
-            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Smoothed diff</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>
-              {metrics.smoothedDifference.toFixed(2)}
-            </div>
+            <div className={styles.metricLabel}>Smoothed diff</div>
+            <div className={styles.metricValue}>{metrics.smoothedDifference.toFixed(2)}</div>
           </div>
           <div>
-            <div style={{ fontSize: '0.75rem', opacity: 0.7 }}>Status</div>
+            <div className={styles.metricLabel}>Status</div>
             <div
-              style={{
-                fontSize: '1rem',
-                fontWeight: 700,
-                color: metrics.isConverged
-                  ? 'var(--green-500, #22c55e)'
-                  : 'var(--text-secondary, #888)',
-              }}
+              className={`${styles.statusValue} ${metrics.isConverged ? styles.statusConverged : ''}`}
             >
               {metrics.isConverged ? 'Converged ✓' : isRunning ? 'Running…' : 'Not converged'}
             </div>
@@ -361,15 +284,7 @@ export function DualSimulation() {
       )}
 
       {/* Information panel */}
-      <div
-        className="info-panel"
-        style={{
-          marginTop: '20px',
-          padding: '20px',
-          background: 'var(--panel-bg)',
-          borderRadius: '8px',
-        }}
-      >
+      <div className={`info-panel ${styles.panel}`}>
         <h3>About Dual Simulation Convergence</h3>
         <p>
           This demonstration runs two 6-vertex model simulations simultaneously with different

--- a/client/src/routes/dwbcDebug.css
+++ b/client/src/routes/dwbcDebug.css
@@ -95,31 +95,31 @@
   background-color: var(--color-bg-primary);
 }
 
-/* Vertex type color coding */
+/* Vertex type color coding (theme-aware tints from the vertex palette) */
 .dwbc-debug__cell--c2 {
   font-weight: var(--font-weight-bold);
-  background-color: #dbeafe; /* Blue tint */
-  color: #1e40af;
+  background-color: color-mix(in srgb, var(--vertex-c2) 22%, var(--color-bg-primary));
+  color: var(--color-text-primary);
 }
 
 .dwbc-debug__cell--a1 {
-  background-color: #dcfce7; /* Green tint */
-  color: #166534;
+  background-color: color-mix(in srgb, var(--vertex-a1) 22%, var(--color-bg-primary));
+  color: var(--color-text-primary);
 }
 
 .dwbc-debug__cell--a2 {
-  background-color: #fef3c7; /* Yellow tint */
-  color: #92400e;
+  background-color: color-mix(in srgb, var(--vertex-a2) 22%, var(--color-bg-primary));
+  color: var(--color-text-primary);
 }
 
 .dwbc-debug__cell--b1 {
-  background-color: #ede9fe; /* Purple tint */
-  color: #5b21b6;
+  background-color: color-mix(in srgb, var(--vertex-b1) 22%, var(--color-bg-primary));
+  color: var(--color-text-primary);
 }
 
 .dwbc-debug__cell--b2 {
-  background-color: #fce7f3; /* Pink tint */
-  color: #9f1239;
+  background-color: color-mix(in srgb, var(--vertex-b2) 22%, var(--color-bg-primary));
+  color: var(--color-text-primary);
 }
 
 .dwbc-debug__cell--mismatch {

--- a/client/src/routes/dwbcDebug.module.css
+++ b/client/src/routes/dwbcDebug.module.css
@@ -1,0 +1,23 @@
+/* Legend swatch background colors for the DWBC debug page.
+ * Uses the canonical vertex palette tokens so light/dark themes stay consistent.
+ * Sizing/border come from the companion .dwbc-debug__legend-color class. */
+
+.swatchA1 {
+  background-color: var(--vertex-a1);
+}
+
+.swatchA2 {
+  background-color: var(--vertex-a2);
+}
+
+.swatchB1 {
+  background-color: var(--vertex-b1);
+}
+
+.swatchB2 {
+  background-color: var(--vertex-b2);
+}
+
+.swatchC2 {
+  background-color: var(--vertex-c2);
+}

--- a/client/src/routes/dwbcDebug.tsx
+++ b/client/src/routes/dwbcDebug.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { generateDWBCHigh, generateDWBCLow } from '../lib/six-vertex/initialStates';
 import type { LatticeState } from '../lib/six-vertex/types';
 import './dwbcDebug.css';
+import styles from './dwbcDebug.module.css';
 
 /**
  * Debug component to display vertex type matrices and compare with paper
@@ -173,38 +174,23 @@ export function DWBCDebug() {
         <h3 className="dwbc-debug__legend-title">Legend:</h3>
         <div className="dwbc-debug__legend-items">
           <div className="dwbc-debug__legend-item">
-            <span
-              className="dwbc-debug__legend-color"
-              style={{ backgroundColor: '#dcfce7' }}
-            ></span>
+            <span className={`dwbc-debug__legend-color ${styles.swatchA1}`}></span>
             <span className="dwbc-debug__legend-label">a1: In(left,top) Out(right,bottom)</span>
           </div>
           <div className="dwbc-debug__legend-item">
-            <span
-              className="dwbc-debug__legend-color"
-              style={{ backgroundColor: '#fef3c7' }}
-            ></span>
+            <span className={`dwbc-debug__legend-color ${styles.swatchA2}`}></span>
             <span className="dwbc-debug__legend-label">a2: In(right,bottom) Out(left,top)</span>
           </div>
           <div className="dwbc-debug__legend-item">
-            <span
-              className="dwbc-debug__legend-color"
-              style={{ backgroundColor: '#ede9fe' }}
-            ></span>
+            <span className={`dwbc-debug__legend-color ${styles.swatchB1}`}></span>
             <span className="dwbc-debug__legend-label">b1: In(left,right) Out(top,bottom)</span>
           </div>
           <div className="dwbc-debug__legend-item">
-            <span
-              className="dwbc-debug__legend-color"
-              style={{ backgroundColor: '#fce7f3' }}
-            ></span>
+            <span className={`dwbc-debug__legend-color ${styles.swatchB2}`}></span>
             <span className="dwbc-debug__legend-label">b2: In(top,bottom) Out(left,right)</span>
           </div>
           <div className="dwbc-debug__legend-item">
-            <span
-              className="dwbc-debug__legend-color"
-              style={{ backgroundColor: '#dbeafe', fontWeight: 'bold' }}
-            ></span>
+            <span className={`dwbc-debug__legend-color ${styles.swatchC2}`}></span>
             <span className="dwbc-debug__legend-label">c2: In(right,top) Out(left,bottom)</span>
           </div>
         </div>

--- a/client/src/routes/dwbcVerify.css
+++ b/client/src/routes/dwbcVerify.css
@@ -4,24 +4,24 @@
   width: 100%;
   max-width: 1400px;
   margin: 0 auto;
-  padding: 2rem;
-  color: #1f2937; /* Dark text for better contrast */
-  background-color: #ffffff;
+  padding: var(--spacing-2xl);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
 }
 
 .dwbc-verify h1 {
-  font-size: 2rem;
-  font-weight: 700;
-  color: #111827;
-  margin-bottom: 1rem;
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-md);
   text-align: center;
 }
 
 .dwbc-verify p {
-  color: #4b5563;
-  font-size: 1rem;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-base);
   line-height: 1.6;
-  margin-bottom: 1.5rem;
+  margin-bottom: var(--spacing-lg);
   text-align: center;
   max-width: 800px;
   margin-left: auto;
@@ -32,33 +32,33 @@
 .dwbc-verify .controls {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: var(--spacing-md);
   justify-content: center;
   align-items: center;
-  padding: 1.5rem;
-  background: #f9fafb;
-  border-radius: 8px;
-  border: 1px solid #e5e7eb;
-  margin-bottom: 2rem;
+  padding: var(--spacing-lg);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--color-border);
+  margin-bottom: var(--spacing-2xl);
 }
 
 .dwbc-verify .controls label {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  color: #374151;
-  font-weight: 500;
-  font-size: 0.875rem;
+  gap: var(--spacing-sm);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
 }
 
 .dwbc-verify .controls input[type='number'],
 .dwbc-verify .controls select {
-  padding: 0.375rem 0.75rem;
-  border: 1px solid #d1d5db;
-  border-radius: 6px;
-  background: white;
-  color: #111827;
-  font-size: 0.875rem;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
   min-width: 80px;
 }
 
@@ -69,72 +69,70 @@
 }
 
 .dwbc-verify .controls button {
-  padding: 0.5rem 1rem;
-  background: #3b82f6;
-  color: white;
+  padding: var(--spacing-sm) var(--spacing-md);
+  background: var(--color-primary);
+  color: var(--color-text-inverse);
   border: none;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.875rem;
+  border-radius: var(--border-radius-md);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition: background-color var(--transition-fast);
 }
 
 .dwbc-verify .controls button:hover {
-  background: #2563eb;
+  background: var(--color-primary-hover);
 }
 
 .dwbc-verify .controls button:active {
-  background: #1d4ed8;
+  background: var(--color-primary-hover);
 }
 
 /* States Container */
 .dwbc-verify .states-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 2rem;
-  margin-bottom: 2rem;
+  gap: var(--spacing-2xl);
+  margin-bottom: var(--spacing-2xl);
 }
 
 /* State Display */
 .dwbc-verify .state-display {
-  background: white;
-  border-radius: 8px;
-  padding: 1.5rem;
-  box-shadow:
-    0 1px 3px 0 rgba(0, 0, 0, 0.1),
-    0 1px 2px 0 rgba(0, 0, 0, 0.06);
-  border: 1px solid #e5e7eb;
+  background: var(--color-bg-primary);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow-sm);
+  border: 1px solid var(--color-border);
 }
 
 .dwbc-verify .state-display h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: #111827;
-  margin-bottom: 0.5rem;
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-sm);
   text-align: center;
 }
 
 /* Ice Rule Status */
 .dwbc-verify .ice-status {
-  padding: 0.5rem 1rem;
-  border-radius: 6px;
-  font-weight: 500;
-  font-size: 0.875rem;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-radius: var(--border-radius-md);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-sm);
   text-align: center;
-  margin-bottom: 1rem;
+  margin-bottom: var(--spacing-md);
 }
 
 .dwbc-verify .ice-status.valid {
-  background: #d1fae5;
-  color: #065f46;
-  border: 1px solid #6ee7b7;
+  background: var(--color-success-light);
+  color: var(--color-success);
+  border: 1px solid var(--color-success);
 }
 
 .dwbc-verify .ice-status.invalid {
-  background: #fee2e2;
-  color: #991b1b;
-  border: 1px solid #fca5a5;
+  background: var(--color-danger-light);
+  color: var(--color-danger);
+  border: 1px solid var(--color-danger);
 }
 
 /* Canvas Container */
@@ -142,103 +140,103 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 1rem;
-  background: #f9fafb;
-  border-radius: 6px;
+  padding: var(--spacing-md);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-md);
   min-height: 400px;
 }
 
 .dwbc-verify canvas {
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
-  background: white;
-  box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-bg-primary);
+  box-shadow: var(--shadow-sm);
 }
 
 /* Vertex Statistics */
 .dwbc-verify .vertex-stats {
-  margin-top: 1rem;
-  padding: 1rem;
-  background: #f9fafb;
-  border-radius: 6px;
-  border: 1px solid #e5e7eb;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-md);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-md);
+  border: 1px solid var(--color-border);
 }
 
 .dwbc-verify .vertex-stats h3 {
-  font-size: 1rem;
-  font-weight: 600;
-  color: #374151;
-  margin-bottom: 0.5rem;
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-sm);
 }
 
 .dwbc-verify .vertex-list {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
-  font-size: 0.875rem;
+  gap: var(--spacing-sm);
+  font-size: var(--font-size-sm);
 }
 
 .dwbc-verify .vertex-list span {
-  padding: 0.25rem 0.5rem;
-  background: white;
-  border-radius: 4px;
-  color: #4b5563;
-  border: 1px solid #e5e7eb;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-bg-primary);
+  border-radius: var(--border-radius-sm);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
 }
 
 /* Physics Test Results */
 .dwbc-verify .physics-test-results {
-  margin-top: 2rem;
-  padding: 1.5rem;
-  background: #fef3c7;
-  border: 1px solid #fcd34d;
-  border-radius: 8px;
+  margin-top: var(--spacing-2xl);
+  padding: var(--spacing-lg);
+  background: var(--color-warning-light);
+  border: 1px solid var(--color-warning);
+  border-radius: var(--border-radius-lg);
 }
 
 .dwbc-verify .physics-test-results h3 {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #92400e;
-  margin-bottom: 1rem;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-warning);
+  margin-bottom: var(--spacing-md);
 }
 
 .dwbc-verify .physics-test-results pre {
-  background: white;
-  padding: 1rem;
-  border-radius: 4px;
+  background: var(--color-bg-primary);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-sm);
   overflow-x: auto;
-  font-size: 0.875rem;
-  color: #1f2937;
-  border: 1px solid #fbbf24;
-  font-family: 'Courier New', monospace;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-warning);
+  font-family: var(--font-family-mono);
   line-height: 1.5;
 }
 
 /* Test Results */
 .dwbc-verify .test-results {
-  margin-top: 2rem;
-  padding: 1.5rem;
-  background: #f0f9ff;
-  border: 1px solid #93c5fd;
-  border-radius: 8px;
+  margin-top: var(--spacing-2xl);
+  padding: var(--spacing-lg);
+  background: var(--color-info-light);
+  border: 1px solid var(--color-info);
+  border-radius: var(--border-radius-lg);
 }
 
 .dwbc-verify .test-results h3 {
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #1e40af;
-  margin-bottom: 1rem;
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-info);
+  margin-bottom: var(--spacing-md);
 }
 
 .dwbc-verify .test-results pre {
-  background: white;
-  padding: 1rem;
-  border-radius: 4px;
+  background: var(--color-bg-primary);
+  padding: var(--spacing-md);
+  border-radius: var(--border-radius-sm);
   overflow-x: auto;
-  font-size: 0.875rem;
-  color: #1f2937;
-  border: 1px solid #60a5fa;
-  font-family: 'Courier New', monospace;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  border: 1px solid var(--color-info);
+  font-family: var(--font-family-mono);
   line-height: 1.5;
 }
 
@@ -251,11 +249,11 @@
 
 @media (max-width: 768px) {
   .dwbc-verify {
-    padding: 1rem;
+    padding: var(--spacing-md);
   }
 
   .dwbc-verify h1 {
-    font-size: 1.5rem;
+    font-size: var(--font-size-2xl);
   }
 
   .dwbc-verify .controls {
@@ -278,17 +276,17 @@
   justify-content: center;
   align-items: center;
   min-height: 400px;
-  color: #6b7280;
-  font-size: 1.125rem;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-lg);
 }
 
 /* Error State */
 .dwbc-verify .error {
-  padding: 1rem;
-  background: #fef2f2;
-  border: 1px solid #fecaca;
-  border-radius: 6px;
-  color: #b91c1c;
-  margin: 1rem 0;
+  padding: var(--spacing-md);
+  background: var(--color-danger-light);
+  border: 1px solid var(--color-danger);
+  border-radius: var(--border-radius-md);
+  color: var(--color-danger);
+  margin: var(--spacing-md) 0;
   text-align: center;
 }

--- a/client/src/routes/flipDebug.module.css
+++ b/client/src/routes/flipDebug.module.css
@@ -1,54 +1,54 @@
 /* FlipDebug Page Styles */
 
 .container {
-  padding: 20px;
-  font-family: 'Courier New', monospace;
-  background-color: #ffffff;
-  color: #1a1a1a;
+  padding: var(--spacing-lg);
+  font-family: var(--font-family-mono);
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
   min-height: 100vh;
 }
 
 .title {
-  color: #2c3e50;
-  margin-bottom: 20px;
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-lg);
   font-size: 1.8rem;
 }
 
 .controls {
-  margin-bottom: 20px;
+  margin-bottom: var(--spacing-lg);
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: var(--spacing-sm);
   flex-wrap: wrap;
 }
 
 .controls label {
-  color: #34495e;
-  font-weight: 600;
+  color: var(--color-text-secondary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .controls select {
-  padding: 4px 8px;
-  border: 1px solid #bdc3c7;
-  border-radius: 4px;
-  background: white;
-  color: #2c3e50;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  background: var(--color-bg-primary);
+  color: var(--color-text-primary);
   font-family: inherit;
 }
 
 .controls button {
-  padding: 6px 12px;
-  background-color: #3498db;
-  color: white;
+  padding: var(--spacing-xs) var(--spacing-md);
+  background-color: var(--color-primary);
+  color: var(--color-text-inverse);
   border: none;
-  border-radius: 4px;
+  border-radius: var(--border-radius-sm);
   cursor: pointer;
-  font-weight: 600;
-  transition: background-color 0.2s;
+  font-weight: var(--font-weight-semibold);
+  transition: background-color var(--transition-fast);
 }
 
 .controls button:hover {
-  background-color: #2980b9;
+  background-color: var(--color-primary-hover);
 }
 
 .controls button:active {
@@ -56,13 +56,13 @@
 }
 
 .stepCounter {
-  color: #2c3e50;
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .mainContent {
   display: flex;
-  gap: 20px;
+  gap: var(--spacing-lg);
   flex-wrap: wrap;
 }
 
@@ -71,64 +71,64 @@
 }
 
 .sectionTitle {
-  color: #2c3e50;
-  margin: 10px 0;
-  font-size: 1.2rem;
+  color: var(--color-text-primary);
+  margin: var(--spacing-sm) 0;
+  font-size: var(--font-size-lg);
 }
 
 .legend {
-  margin-top: 15px;
-  padding: 10px;
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
-  border-radius: 4px;
+  margin-top: var(--spacing-md);
+  padding: var(--spacing-sm);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
 }
 
 .legendTitle {
-  color: #495057;
-  margin: 0 0 10px 0;
-  font-size: 1rem;
+  color: var(--color-text-secondary);
+  margin: 0 0 var(--spacing-sm) 0;
+  font-size: var(--font-size-base);
 }
 
 .vertexGrid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
+  gap: var(--spacing-sm);
 }
 
 .vertexItem {
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 4px;
-  background: white;
-  border: 1px solid #e9ecef;
-  border-radius: 4px;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-xs);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
 }
 
 .vertexColor {
   width: 24px;
   height: 24px;
-  border: 1px solid #6c757d;
+  border: 1px solid var(--color-border-dark);
   border-radius: 3px;
   flex-shrink: 0;
 }
 
 .vertexLabel {
-  color: #212529;
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
   font-size: 0.9rem;
   min-width: 24px;
 }
 
 .vertexArrows {
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-family-mono);
   font-size: 1.1rem;
-  color: #495057;
+  color: var(--color-text-secondary);
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f1f3f5;
+  background: var(--color-bg-tertiary);
   padding: 2px 6px;
   border-radius: 3px;
   white-space: pre;
@@ -143,136 +143,136 @@
 .flipHistory {
   max-height: 400px;
   overflow-y: auto;
-  border: 1px solid #dee2e6;
-  padding: 10px;
-  background: #f8f9fa;
-  border-radius: 4px;
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-sm);
+  background: var(--color-bg-secondary);
+  border-radius: var(--border-radius-sm);
 }
 
 .flipEntry {
-  margin-bottom: 10px;
-  padding: 10px;
-  background: white;
+  margin-bottom: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  background: var(--color-bg-primary);
   cursor: pointer;
-  border: 1px solid #dee2e6;
-  border-radius: 4px;
-  transition: all 0.2s;
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
+  transition: all var(--transition-fast);
 }
 
 .flipEntry:hover {
-  background: #e9ecef;
-  border-color: #adb5bd;
+  background: var(--color-bg-hover);
+  border-color: var(--color-border-hover);
 }
 
 .flipEntry.selected {
-  background: #e3f2fd;
-  border-color: #2196f3;
-  box-shadow: 0 0 0 1px #2196f3;
+  background: var(--color-primary-light);
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 1px var(--color-primary);
 }
 
 .flipEntry.hasViolation {
-  border: 2px solid #dc3545;
-  background: #fff5f5;
+  border: 2px solid var(--color-danger);
+  background: var(--color-danger-light);
 }
 
 .flipEntryHeader {
-  color: #212529;
-  font-weight: 600;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .violationWarning {
-  color: #dc3545;
-  margin-top: 5px;
-  font-weight: 600;
+  color: var(--color-danger);
+  margin-top: var(--spacing-xs);
+  font-weight: var(--font-weight-semibold);
 }
 
 .flipDetails {
-  margin-top: 20px;
-  padding: 15px;
-  background: #f8f9fa;
-  border: 1px solid #dee2e6;
-  border-radius: 4px;
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-md);
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
 }
 
 .flipDetailsTitle {
-  color: #212529;
-  margin: 0 0 10px 0;
-  font-size: 1.1rem;
+  color: var(--color-text-primary);
+  margin: 0 0 var(--spacing-sm) 0;
+  font-size: var(--font-size-lg);
 }
 
 .flipDetailsInfo {
-  color: #495057;
-  margin: 5px 0;
+  color: var(--color-text-secondary);
+  margin: var(--spacing-xs) 0;
 }
 
 .flipTable {
   border-collapse: collapse;
   width: 100%;
-  margin-top: 10px;
-  background: white;
+  margin-top: var(--spacing-sm);
+  background: var(--color-bg-primary);
 }
 
 .flipTable th,
 .flipTable td {
-  border: 1px solid #dee2e6;
-  padding: 8px;
+  border: 1px solid var(--color-border);
+  padding: var(--spacing-sm);
   text-align: left;
 }
 
 .flipTable th {
-  background: #e9ecef;
-  color: #212529;
-  font-weight: 600;
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-semibold);
 }
 
 .flipTable td {
-  color: #212529;
-  font-weight: 500;
+  color: var(--color-text-primary);
+  font-weight: var(--font-weight-medium);
 }
 
 .flipTableSubtitle {
-  color: #495057;
-  margin: 10px 0 5px 0;
-  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin: var(--spacing-sm) 0 var(--spacing-xs) 0;
+  font-weight: var(--font-weight-semibold);
 }
 
 .violationSummary {
-  margin-top: 20px;
-  padding: 15px;
-  background: #f8d7da;
-  border: 2px solid #f5c6cb;
-  border-radius: 4px;
+  margin-top: var(--spacing-lg);
+  padding: var(--spacing-md);
+  background: var(--color-danger-light);
+  border: 2px solid var(--color-danger);
+  border-radius: var(--border-radius-sm);
 }
 
 .violationSummary h3 {
-  color: #721c24;
-  margin: 0 0 10px 0;
+  color: var(--color-danger);
+  margin: 0 0 var(--spacing-sm) 0;
 }
 
 .violationSummary ul {
   margin: 0;
-  padding-left: 20px;
-  color: #721c24;
+  padding-left: var(--spacing-lg);
+  color: var(--color-danger);
 }
 
 .violationSummary li {
-  margin: 5px 0;
+  margin: var(--spacing-xs) 0;
 }
 
 /* SVG text visibility fix */
 .vertexText {
-  fill: #000000;
+  fill: var(--color-text-primary);
   font-weight: bold;
-  font-family: 'Courier New', monospace;
+  font-family: var(--font-family-mono);
   user-select: none;
-  stroke: white;
+  stroke: var(--color-bg-primary);
   stroke-width: 0.5px;
   paint-order: stroke;
 }
 
 /* Grid lines */
 .gridLine {
-  stroke: #dee2e6;
+  stroke: var(--color-border);
   stroke-width: 1;
 }
 
@@ -282,29 +282,29 @@
 }
 
 .vertexRect.highlighted {
-  stroke: #000000;
+  stroke: var(--color-text-primary);
   stroke-width: 3;
 }
 
 .vertexRect.violation {
-  stroke: #dc3545;
+  stroke: var(--color-danger);
   stroke-width: 2;
 }
 
 /* Flip region highlight */
 .flipRegion {
   fill: none;
-  stroke: #0066cc;
+  stroke: var(--color-primary);
   stroke-width: 2;
   stroke-dasharray: 4, 2;
 }
 
 /* Legend note */
 .legendNote {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid #dee2e6;
-  color: #6c757d;
+  margin-top: var(--spacing-sm);
+  padding-top: var(--spacing-sm);
+  border-top: 1px solid var(--color-border);
+  color: var(--color-text-muted);
   font-size: 0.9rem;
   font-style: italic;
 }
@@ -314,12 +314,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 20px;
-  margin: 20px 0;
-  padding: 15px;
-  background: white;
-  border: 1px solid #dee2e6;
-  border-radius: 4px;
+  gap: var(--spacing-lg);
+  margin: var(--spacing-lg) 0;
+  padding: var(--spacing-md);
+  background: var(--color-bg-primary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-sm);
 }
 
 .plaquetteBefore,
@@ -329,14 +329,14 @@
 
 .plaquetteBefore h5,
 .plaquetteAfter h5 {
-  margin: 0 0 10px 0;
-  color: #495057;
+  margin: 0 0 var(--spacing-sm) 0;
+  color: var(--color-text-secondary);
   font-size: 0.95rem;
-  font-weight: 600;
+  font-weight: var(--font-weight-semibold);
 }
 
 .flipArrow {
   font-size: 2rem;
-  color: #3498db;
+  color: var(--color-primary);
   font-weight: bold;
 }

--- a/client/src/routes/flipDebug.tsx
+++ b/client/src/routes/flipDebug.tsx
@@ -11,7 +11,9 @@ import {
   generateDWBCHighOptimized,
 } from '../lib/six-vertex/optimizedSimulation';
 import { VertexLegend, PlaquetteVisualization } from '../components/VertexEdgeVisualization';
+import { getCurrentVertexColors } from '../lib/six-vertex/themeColors';
 import styles from './flipDebug.module.css';
+import swatches from './flipDebugSwatches.module.css';
 
 // Map numeric vertex types to enum
 const NUM_TO_VERTEX_TYPE = [
@@ -23,14 +25,14 @@ const NUM_TO_VERTEX_TYPE = [
   VertexType.c2,
 ];
 
-// Vertex colors for visualization
-const VERTEX_COLORS: Record<VertexType, string> = {
-  [VertexType.a1]: '#ff6b6b', // Red
-  [VertexType.a2]: '#4ecdc4', // Teal
-  [VertexType.b1]: '#45b7d1', // Blue
-  [VertexType.b2]: '#96ceb4', // Green
-  [VertexType.c1]: '#ffd93d', // Yellow
-  [VertexType.c2]: '#c9a0ff', // Purple
+// Token-based background class for a vertex type (reacts to theme automatically).
+const VERTEX_CELL_CLASS: Record<VertexType, string> = {
+  [VertexType.a1]: swatches.cellA1,
+  [VertexType.a2]: swatches.cellA2,
+  [VertexType.b1]: swatches.cellB1,
+  [VertexType.b2]: swatches.cellB2,
+  [VertexType.c1]: swatches.cellC1,
+  [VertexType.c2]: swatches.cellC2,
 };
 
 // Visual arrow representations for each vertex type
@@ -367,6 +369,7 @@ export function FlipDebug() {
     if (!currentState) return null;
 
     const cellSize = Math.min(60, 400 / size);
+    const vertexColors = getCurrentVertexColors();
 
     return (
       <svg width={size * cellSize} height={size * cellSize}>
@@ -406,7 +409,7 @@ export function FlipDebug() {
                   y={row * cellSize + 2}
                   width={cellSize - 4}
                   height={cellSize - 4}
-                  fill={VERTEX_COLORS[vertexType]}
+                  fill={vertexColors[vertexType]}
                   className={`${styles.vertexRect} ${isHighlighted ? styles.highlighted : ''} ${hasViolation ? styles.violation : ''}`}
                 />
 
@@ -416,7 +419,7 @@ export function FlipDebug() {
                   cx={col * cellSize + cellSize / 2}
                   cy={row * cellSize + cellSize / 2}
                   r={3}
-                  fill="#333"
+                  className={swatches.centerDot}
                 />
 
                 {/* Draw bold lines for paths */}
@@ -426,9 +429,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2}
                     x2={col * cellSize + cellSize / 2 - 3}
                     y2={row * cellSize + cellSize / 2}
-                    stroke="#333"
-                    strokeWidth={5}
-                    strokeLinecap="round"
+                    className={swatches.pathBold}
                   />
                 )}
                 {edges.right && (
@@ -437,9 +438,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2}
                     x2={col * cellSize + cellSize - 3}
                     y2={row * cellSize + cellSize / 2}
-                    stroke="#333"
-                    strokeWidth={5}
-                    strokeLinecap="round"
+                    className={swatches.pathBold}
                   />
                 )}
                 {edges.top && (
@@ -448,9 +447,7 @@ export function FlipDebug() {
                     y1={row * cellSize + 3}
                     x2={col * cellSize + cellSize / 2}
                     y2={row * cellSize + cellSize / 2 - 3}
-                    stroke="#333"
-                    strokeWidth={5}
-                    strokeLinecap="round"
+                    className={swatches.pathBold}
                   />
                 )}
                 {edges.bottom && (
@@ -459,9 +456,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2 + 3}
                     x2={col * cellSize + cellSize / 2}
                     y2={row * cellSize + cellSize - 3}
-                    stroke="#333"
-                    strokeWidth={5}
-                    strokeLinecap="round"
+                    className={swatches.pathBold}
                   />
                 )}
 
@@ -472,9 +467,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2}
                     x2={col * cellSize + cellSize / 2 - 3}
                     y2={row * cellSize + cellSize / 2}
-                    stroke="#999"
-                    strokeWidth={1}
-                    strokeLinecap="round"
+                    className={swatches.pathThin}
                   />
                 )}
                 {!edges.right && (
@@ -483,9 +476,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2}
                     x2={col * cellSize + cellSize - 3}
                     y2={row * cellSize + cellSize / 2}
-                    stroke="#999"
-                    strokeWidth={1}
-                    strokeLinecap="round"
+                    className={swatches.pathThin}
                   />
                 )}
                 {!edges.top && (
@@ -494,9 +485,7 @@ export function FlipDebug() {
                     y1={row * cellSize + 3}
                     x2={col * cellSize + cellSize / 2}
                     y2={row * cellSize + cellSize / 2 - 3}
-                    stroke="#999"
-                    strokeWidth={1}
-                    strokeLinecap="round"
+                    className={swatches.pathThin}
                   />
                 )}
                 {!edges.bottom && (
@@ -505,9 +494,7 @@ export function FlipDebug() {
                     y1={row * cellSize + cellSize / 2 + 3}
                     x2={col * cellSize + cellSize / 2}
                     y2={row * cellSize + cellSize - 3}
-                    stroke="#999"
-                    strokeWidth={1}
-                    strokeLinecap="round"
+                    className={swatches.pathThin}
                   />
                 )}
 
@@ -674,10 +661,10 @@ export function FlipDebug() {
                 <tbody>
                   <tr>
                     <td>Base</td>
-                    <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.base] }}>
+                    <td className={VERTEX_CELL_CLASS[selectedFlip.before.base]}>
                       {selectedFlip.before.base} {VERTEX_ARROWS[selectedFlip.before.base]}
                     </td>
-                    <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.base] }}>
+                    <td className={VERTEX_CELL_CLASS[selectedFlip.after.base]}>
                       {selectedFlip.after.base} {VERTEX_ARROWS[selectedFlip.after.base]}
                     </td>
                   </tr>
@@ -686,10 +673,10 @@ export function FlipDebug() {
                       {selectedFlip.before.right && (
                         <tr>
                           <td>Right</td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.right] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.right]}>
                             {selectedFlip.before.right} {VERTEX_ARROWS[selectedFlip.before.right]}
                           </td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.right!] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.right!]}>
                             {selectedFlip.after.right} {VERTEX_ARROWS[selectedFlip.after.right!]}
                           </td>
                         </tr>
@@ -697,10 +684,10 @@ export function FlipDebug() {
                       {selectedFlip.before.up && (
                         <tr>
                           <td>Up</td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.up] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.up]}>
                             {selectedFlip.before.up} {VERTEX_ARROWS[selectedFlip.before.up]}
                           </td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.up!] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.up!]}>
                             {selectedFlip.after.up} {VERTEX_ARROWS[selectedFlip.after.up!]}
                           </td>
                         </tr>
@@ -708,15 +695,11 @@ export function FlipDebug() {
                       {selectedFlip.before.upRight && (
                         <tr>
                           <td>Up-Right</td>
-                          <td
-                            style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.upRight] }}
-                          >
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.upRight]}>
                             {selectedFlip.before.upRight}{' '}
                             {VERTEX_ARROWS[selectedFlip.before.upRight]}
                           </td>
-                          <td
-                            style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.upRight!] }}
-                          >
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.upRight!]}>
                             {selectedFlip.after.upRight}{' '}
                             {VERTEX_ARROWS[selectedFlip.after.upRight!]}
                           </td>
@@ -728,10 +711,10 @@ export function FlipDebug() {
                       {selectedFlip.before.left && (
                         <tr>
                           <td>Left</td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.left] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.left]}>
                             {selectedFlip.before.left} {VERTEX_ARROWS[selectedFlip.before.left]}
                           </td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.left!] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.left!]}>
                             {selectedFlip.after.left} {VERTEX_ARROWS[selectedFlip.after.left!]}
                           </td>
                         </tr>
@@ -739,10 +722,10 @@ export function FlipDebug() {
                       {selectedFlip.before.down && (
                         <tr>
                           <td>Down</td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.down] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.down]}>
                             {selectedFlip.before.down} {VERTEX_ARROWS[selectedFlip.before.down]}
                           </td>
-                          <td style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.down!] }}>
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.down!]}>
                             {selectedFlip.after.down} {VERTEX_ARROWS[selectedFlip.after.down!]}
                           </td>
                         </tr>
@@ -750,15 +733,11 @@ export function FlipDebug() {
                       {selectedFlip.before.downLeft && (
                         <tr>
                           <td>Down-Left</td>
-                          <td
-                            style={{ backgroundColor: VERTEX_COLORS[selectedFlip.before.downLeft] }}
-                          >
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.before.downLeft]}>
                             {selectedFlip.before.downLeft}{' '}
                             {VERTEX_ARROWS[selectedFlip.before.downLeft]}
                           </td>
-                          <td
-                            style={{ backgroundColor: VERTEX_COLORS[selectedFlip.after.downLeft!] }}
-                          >
+                          <td className={VERTEX_CELL_CLASS[selectedFlip.after.downLeft!]}>
                             {selectedFlip.after.downLeft}{' '}
                             {VERTEX_ARROWS[selectedFlip.after.downLeft!]}
                           </td>

--- a/client/src/routes/flipDebugSwatches.module.css
+++ b/client/src/routes/flipDebugSwatches.module.css
@@ -1,0 +1,41 @@
+/* Additional token-based classes for the flip debugger.
+ * Kept in a separate (new) module so the existing flipDebug.module.css is untouched.
+ * The six vertex-background classes mirror getCurrentVertexColors() but resolve
+ * through CSS custom properties so they react to theme changes automatically. */
+
+/* Table-cell vertex backgrounds (used in the 2x2-neighborhood change table). */
+.cellA1 {
+  background-color: var(--vertex-a1);
+}
+.cellA2 {
+  background-color: var(--vertex-a2);
+}
+.cellB1 {
+  background-color: var(--vertex-b1);
+}
+.cellB2 {
+  background-color: var(--vertex-b2);
+}
+.cellC1 {
+  background-color: var(--vertex-c1);
+}
+.cellC2 {
+  background-color: var(--vertex-c2);
+}
+
+/* SVG path/marker chrome — bold path segments and the central vertex dot. */
+.pathBold {
+  stroke: var(--color-text-primary);
+  stroke-width: 5;
+  stroke-linecap: round;
+}
+
+.pathThin {
+  stroke: var(--color-text-muted);
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+
+.centerDot {
+  fill: var(--color-text-primary);
+}

--- a/client/src/routes/heightDemo.module.css
+++ b/client/src/routes/heightDemo.module.css
@@ -1,0 +1,88 @@
+/* Height-function demo route. Token-based chrome so light/dark themes work.
+ * The heatmap cell *fill* colors are a numeric gradient computed in JS and set
+ * via a single CSS custom property (--cell-bg); everything else uses tokens. */
+
+.page {
+  padding: var(--spacing-xl);
+}
+
+.controls {
+  margin-bottom: var(--spacing-xl);
+}
+
+.controlRow {
+  margin-bottom: var(--spacing-sm);
+}
+
+.rangeInput {
+  margin-left: var(--spacing-sm);
+  margin-right: var(--spacing-sm);
+}
+
+.radioLabel {
+  margin-right: var(--spacing-xl);
+}
+
+.selectLabel {
+  margin-right: var(--spacing-xl);
+}
+
+.select {
+  margin-left: var(--spacing-sm);
+}
+
+.stats {
+  margin-bottom: var(--spacing-xl);
+}
+
+.heightGrid {
+  display: inline-block;
+}
+
+.heatmap {
+  display: grid;
+  gap: 1px;
+  background-color: var(--color-border);
+  padding: 1px;
+  border: 2px solid var(--color-border-dark);
+}
+
+.cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: var(--font-weight-bold);
+  border: 1px solid var(--color-border-light);
+  background-color: var(--cell-bg);
+  color: var(--color-text-inverse);
+}
+
+.cell--hideValues {
+  color: transparent;
+}
+
+.legend {
+  margin-top: var(--spacing-xl);
+}
+
+.legendBar {
+  width: 300px;
+  height: 30px;
+  border: 1px solid var(--color-border-dark);
+  background: var(--legend-gradient);
+}
+
+.legendScale {
+  display: flex;
+  justify-content: space-between;
+  width: 300px;
+}
+
+.about {
+  margin-top: var(--spacing-2xl);
+}
+
+.prose {
+  max-width: 600px;
+  line-height: 1.6;
+}

--- a/client/src/routes/heightDemo.tsx
+++ b/client/src/routes/heightDemo.tsx
@@ -7,6 +7,7 @@ import { generateDWBCState } from '../lib/six-vertex/initialStates';
 import { calculateHeightFunction, type HeightData } from '../lib/six-vertex/heightFunction';
 import type { LatticeState, DWBCConfig } from '../lib/six-vertex/types';
 import '../App.css';
+import styles from './heightDemo.module.css';
 
 export function HeightDemo() {
   const [size, setSize] = useState(8);
@@ -73,27 +74,26 @@ export function HeightDemo() {
   const cellSize = Math.min(600 / size, 60);
 
   return (
-    <div className="height-demo" style={{ padding: '20px' }}>
+    <div className={`height-demo ${styles.page}`}>
       <h1>Height Function Visualization</h1>
 
-      <div className="controls" style={{ marginBottom: '20px' }}>
-        <div style={{ marginBottom: '10px' }}>
-          <label>
-            Size:
-            <input
-              type="range"
-              min="4"
-              max="24"
-              value={size}
-              onChange={(e) => setSize(Number(e.target.value))}
-              style={{ marginLeft: '10px', marginRight: '10px' }}
-            />
-            {size}×{size}
-          </label>
+      <div className={`controls ${styles.controls}`}>
+        <div className={styles.controlRow}>
+          <label htmlFor="height-size">Size: </label>
+          <input
+            id="height-size"
+            type="range"
+            min="4"
+            max="24"
+            value={size}
+            onChange={(e) => setSize(Number(e.target.value))}
+            className={styles.rangeInput}
+          />
+          {size}×{size}
         </div>
 
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ marginRight: '20px' }}>
+        <div className={styles.controlRow}>
+          <label className={styles.radioLabel}>
             <input
               type="radio"
               value="high"
@@ -113,21 +113,22 @@ export function HeightDemo() {
           </label>
         </div>
 
-        <div style={{ marginBottom: '10px' }}>
-          <label style={{ marginRight: '20px' }}>
+        <div className={styles.controlRow}>
+          <label className={styles.selectLabel} htmlFor="height-color-scale">
             Color Scale:
-            <select
-              value={colorScale}
-              onChange={(e) => setColorScale(e.target.value as 'blue' | 'heat' | 'grayscale')}
-              style={{ marginLeft: '10px' }}
-            >
-              <option value="heat">Heat Map</option>
-              <option value="blue">Blue Scale</option>
-              <option value="grayscale">Grayscale</option>
-            </select>
           </label>
+          <select
+            id="height-color-scale"
+            value={colorScale}
+            onChange={(e) => setColorScale(e.target.value as 'blue' | 'heat' | 'grayscale')}
+            className={styles.select}
+          >
+            <option value="heat">Heat Map</option>
+            <option value="blue">Blue Scale</option>
+            <option value="grayscale">Grayscale</option>
+          </select>
 
-          <label>
+          <label className={styles.selectLabel}>
             <input
               type="checkbox"
               checked={showValues}
@@ -137,12 +138,12 @@ export function HeightDemo() {
           </label>
         </div>
 
-        <button onClick={generateLattice} style={{ padding: '5px 15px' }}>
+        <button type="button" onClick={generateLattice} className="btn btn--secondary btn--small">
           Regenerate
         </button>
       </div>
 
-      <div className="stats" style={{ marginBottom: '20px' }}>
+      <div className={`stats ${styles.stats}`}>
         <h3>Statistics</h3>
         <p>Total Volume: {heightData.totalVolume.toFixed(2)}</p>
         <p>Average Height: {heightData.averageHeight.toFixed(3)}</p>
@@ -151,65 +152,66 @@ export function HeightDemo() {
         <p>Range: {heightData.maxHeight - heightData.minHeight}</p>
       </div>
 
-      <div className="height-grid" style={{ display: 'inline-block' }}>
+      <div className={`height-grid ${styles.heightGrid}`}>
         <h3>Height Function Heatmap</h3>
         <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: `repeat(${size}, ${cellSize}px)`,
-            gridTemplateRows: `repeat(${size}, ${cellSize}px)`,
-            gap: '1px',
-            backgroundColor: '#e0e0e0',
-            padding: '1px',
-            border: '2px solid #333',
-          }}
+          className={styles.heatmap}
+          style={
+            {
+              gridTemplateColumns: `repeat(${size}, ${cellSize}px)`,
+              gridTemplateRows: `repeat(${size}, ${cellSize}px)`,
+            } as React.CSSProperties
+          }
         >
           {heightData.heights.map((row, rowIdx) =>
-            row.map((height, colIdx) => (
-              <div
-                key={`${rowIdx}-${colIdx}`}
-                style={{
-                  width: cellSize,
-                  height: cellSize,
-                  backgroundColor: getHeightColor(
-                    height,
-                    heightData.minHeight,
-                    heightData.maxHeight,
-                  ),
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  fontSize: cellSize > 30 && showValues ? `${Math.min(cellSize / 3, 14)}px` : '0',
-                  color: showValues ? '#fff' : 'transparent',
-                  fontWeight: 'bold',
-                  textShadow: showValues ? '1px 1px 2px rgba(0,0,0,0.8)' : 'none',
-                  border: '1px solid rgba(255,255,255,0.1)',
-                }}
-                title={`Position (${rowIdx},${colIdx}): Height = ${height}`}
-              >
-                {showValues && cellSize > 30 ? height : ''}
-              </div>
-            )),
+            row.map((height, colIdx) => {
+              const showCellValue = showValues && cellSize > 30;
+              return (
+                <div
+                  key={`${rowIdx}-${colIdx}`}
+                  className={`${styles.cell} ${showValues ? '' : styles['cell--hideValues']}`}
+                  style={
+                    {
+                      width: cellSize,
+                      height: cellSize,
+                      fontSize: showCellValue ? `${Math.min(cellSize / 3, 14)}px` : 0,
+                      '--cell-bg': getHeightColor(
+                        height,
+                        heightData.minHeight,
+                        heightData.maxHeight,
+                      ),
+                    } as React.CSSProperties
+                  }
+                  title={`Position (${rowIdx},${colIdx}): Height = ${height}`}
+                >
+                  {showCellValue ? height : ''}
+                </div>
+              );
+            }),
           )}
         </div>
 
         {/* Color scale legend */}
-        <div style={{ marginTop: '20px' }}>
+        <div className={styles.legend}>
           <h4>Color Scale</h4>
           <div
-            style={{
-              width: '300px',
-              height: '30px',
-              background: `linear-gradient(to right, ${Array.from({ length: 20 }, (_, i) => {
-                const normalized = i / 19;
-                const value =
-                  heightData.minHeight + normalized * (heightData.maxHeight - heightData.minHeight);
-                return getHeightColor(value, heightData.minHeight, heightData.maxHeight);
-              }).join(', ')})`,
-              border: '1px solid #333',
-            }}
+            className={styles.legendBar}
+            style={
+              {
+                '--legend-gradient': `linear-gradient(to right, ${Array.from(
+                  { length: 20 },
+                  (_, i) => {
+                    const normalized = i / 19;
+                    const value =
+                      heightData.minHeight +
+                      normalized * (heightData.maxHeight - heightData.minHeight);
+                    return getHeightColor(value, heightData.minHeight, heightData.maxHeight);
+                  },
+                ).join(', ')})`,
+              } as React.CSSProperties
+            }
           />
-          <div style={{ display: 'flex', justifyContent: 'space-between', width: '300px' }}>
+          <div className={styles.legendScale}>
             <span>{heightData.minHeight}</span>
             <span>{((heightData.minHeight + heightData.maxHeight) / 2).toFixed(1)}</span>
             <span>{heightData.maxHeight}</span>
@@ -217,14 +219,14 @@ export function HeightDemo() {
         </div>
       </div>
 
-      <div style={{ marginTop: '30px' }}>
+      <div className={styles.about}>
         <h3>About the Height Function</h3>
-        <p style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+        <p className={styles.prose}>
           The height function is a fundamental concept in the 6-vertex model. It is calculated by
           counting specific edge crossings when traveling from the origin (0,0) to each vertex.
           Specifically:
         </p>
-        <ul style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+        <ul className={styles.prose}>
           <li>When an edge points LEFT into a vertex, the height increases by +1</li>
           <li>When an edge points DOWN into a vertex, the height increases by +1</li>
           <li>The total volume is the sum of all vertex heights</li>
@@ -232,7 +234,7 @@ export function HeightDemo() {
             The height function provides insight into the macroscopic properties of the system
           </li>
         </ul>
-        <p style={{ maxWidth: '600px', lineHeight: '1.6' }}>
+        <p className={styles.prose}>
           In DWBC (Domain Wall Boundary Conditions), the height function exhibits characteristic
           patterns that differ between the "high" and "low" configurations, reflecting the
           underlying vertex arrangements.

--- a/client/src/routes/modelTests.css
+++ b/client/src/routes/modelTests.css
@@ -5,6 +5,7 @@
   min-height: 100vh;
 }
 
+/* Header is an intentional always-dark banner (theme-independent) with inverse text. */
 .tests-page__header {
   background: linear-gradient(135deg, #1f2937 0%, #374151 100%);
   color: var(--color-text-inverse);
@@ -110,17 +111,17 @@
 
 .test-suite__status--passing {
   background-color: var(--color-success-light);
-  color: #155724;
+  color: var(--color-success);
 }
 
 .test-suite__status--failing {
   background-color: var(--color-danger-light);
-  color: #721c24;
+  color: var(--color-danger);
 }
 
 .test-suite__status--pending {
   background-color: var(--color-warning-light);
-  color: #856404;
+  color: var(--color-warning);
 }
 
 /* Test List */
@@ -196,7 +197,11 @@
   transform: none;
 }
 
-/* Test Results */
+/*
+ * Test Results is an intentional always-dark terminal surface (VS Code style),
+ * deliberately theme-independent so log output reads the same in both modes.
+ * The syntax-highlight colors below are part of that fixed terminal palette.
+ */
 .test-results {
   background-color: #1e1e1e;
   color: #d4d4d4;

--- a/client/src/routes/performanceDemo.css
+++ b/client/src/routes/performanceDemo.css
@@ -101,7 +101,7 @@
 }
 
 .performance-controls__button--stop:hover {
-  background-color: #b02a37;
+  background-color: color-mix(in srgb, var(--color-danger) 85%, black);
 }
 
 /* Stats Display */
@@ -182,18 +182,22 @@
 }
 
 .performance-tests__button--comprehensive:hover {
-  background-color: #218838;
+  background-color: color-mix(in srgb, var(--color-success) 85%, black);
 }
 
 .performance-tests__button--fps {
-  background-color: #6f42c1;
+  background-color: var(--color-info);
 }
 
 .performance-tests__button--fps:hover {
-  background-color: #5a32a3;
+  background-color: color-mix(in srgb, var(--color-info) 85%, black);
 }
 
 /* Console Output */
+/*
+ * Console is an intentional always-dark terminal surface (VS Code style),
+ * deliberately theme-independent so log output reads the same in both modes.
+ */
 .performance-console {
   background-color: #1e1e1e;
   color: #4ec9b0;
@@ -219,13 +223,13 @@
   padding: var(--spacing-lg);
   background-color: var(--color-info-light);
   border-radius: var(--border-radius-md);
-  border: 1px solid #b8daff;
+  border: 1px solid var(--color-info);
 }
 
 .performance-info__title {
   font-weight: var(--font-weight-semibold);
   margin-bottom: var(--spacing-sm);
-  color: #004085;
+  color: var(--color-info);
 }
 
 .performance-info__list {
@@ -238,7 +242,7 @@
   padding: var(--spacing-xs) 0;
   display: flex;
   justify-content: space-between;
-  color: #004085;
+  color: var(--color-text-primary);
   font-size: var(--font-size-sm);
 }
 
@@ -255,15 +259,15 @@
 .performance-optimizations {
   margin-top: var(--spacing-lg);
   padding: var(--spacing-lg);
-  background-color: #fff3cd;
+  background-color: var(--color-warning-light);
   border-radius: var(--border-radius-md);
-  border: 1px solid #ffeeba;
+  border: 1px solid var(--color-warning);
 }
 
 .performance-optimizations__title {
   font-weight: var(--font-weight-semibold);
   margin-bottom: var(--spacing-sm);
-  color: #856404;
+  color: var(--color-warning);
 }
 
 .performance-optimizations__list {
@@ -274,7 +278,7 @@
 
 .performance-optimizations__item {
   padding: var(--spacing-xs) 0;
-  color: #856404;
+  color: var(--color-text-primary);
   font-size: var(--font-size-sm);
 }
 

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -87,6 +87,20 @@
   /* Scrollbar */
   --color-scrollbar-thumb: #888;
   --color-scrollbar-thumb-hover: #555;
+
+  /* Surfaces (aliases used by route panels) */
+  --panel-bg: var(--color-bg-secondary);
+  --color-bg-quaternary: #dde1e6;
+  --color-border-dark: #ced4da;
+
+  /* Vertex-type palette (Okabe–Ito, CVD-safe). Single source of truth shared
+     with the Canvas via src/lib/six-vertex/themeColors.ts — keep in sync. */
+  --vertex-a1: #d55e00;
+  --vertex-a2: #e69f00;
+  --vertex-b1: #0072b2;
+  --vertex-b2: #56b4e9;
+  --vertex-c1: #009e73;
+  --vertex-c2: #cc79a7;
 }
 
 /* Dark Theme */
@@ -132,6 +146,19 @@
   /* Scrollbar */
   --color-scrollbar-thumb: #606060;
   --color-scrollbar-thumb-hover: #808080;
+
+  /* Surfaces */
+  --panel-bg: var(--color-bg-secondary);
+  --color-bg-quaternary: #505050;
+  --color-border-dark: #2a2a2a;
+
+  /* Vertex-type palette (brightened for the dark background) */
+  --vertex-a1: #ff7d3b;
+  --vertex-a2: #ffbf47;
+  --vertex-b1: #4da3ff;
+  --vertex-b2: #8fd0f5;
+  --vertex-c1: #3ad4a8;
+  --vertex-c2: #e89cc4;
 }
 
 /* ===========================


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-39.dev.6v.allison.la

## Summary
Comprehensive UX/frontend pass driven by a two-part audit (two independent agents). The verdict from both: **stay on plain React + CSS** — no Tailwind / component-library swap — and instead consolidate the design-token system that was already ~80% in place. This PR does exactly that, then fixes the bugs the audit surfaced.

## Changes
**Design-system foundation**
- Add previously-undefined tokens (`--panel-bg`, `--color-bg-quaternary`, `--color-border-dark`) in both themes.
- Establish ONE canonical, CVD-safe (Okabe–Ito) vertex palette — as CSS vars (`--vertex-a1..--vertex-c2`) and as a single TS source (`getCurrentVertexColors`) — consumed by the Canvas **and** every DOM legend. Previously three different hardcoded palettes disagreed, so the legend lied about the canvas colors.

**Theming fixes**
- Make every route theme-aware. `/dwbc-verify` (and other route CSS) hardcoded light-only colors and rendered as a **white sheet in dark mode**; now token-driven.
- Tokenize `App.css` dark overrides; theme the `ErrorBoundary` (was light-only).

**Cleanup**
- Eliminate ~80 inline `style={{}}` blocks across route components into token-based CSS modules; replace undefined `--green/red/blue/purple-500` refs with semantic tokens + global `.btn` utilities.

**UX + a11y**
- Replace `alert()` error popups with an in-UI dismissible `.alert--danger` banner.
- Auto-fit the lattice to the canvas on load and on N change (was tiny by default).
- Flat canvas background instead of the checkerboard.
- `aria-valuetext` on sliders, `aria-live`/`<output>` on numeric readouts, `role="alert"`.

## Testing
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — OK
- [x] `npm test` — 21 suites / 282 tests pass
- [x] Manual: both light and dark themes verified across all routes in-browser, no console errors

## Related Issues
Refs #9

## Checklist
- [x] Code follows project conventions
- [x] Tests pass locally
- [x] No framework additions (plain CSS + custom properties)
- [x] CI checks pass
- [x] Preview link included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
