### PR TITLE
Pan & zoom large lattices in the dual simulation — reusable PanZoomCanvas (#38)

### DIFF
--- a/client/src/components/DualSimulationDisplay.tsx
+++ b/client/src/components/DualSimulationDisplay.tsx
@@ -1,15 +1,20 @@
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import { useRef, useEffect } from 'react';
 import type { LatticeState } from '../lib/six-vertex/types';
 import { PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
 import { RenderMode } from '../lib/six-vertex/types';
+import { PanZoomCanvas } from './PanZoomCanvas';
 import './DualSimulationDisplay.css';
 
 interface DualSimulationDisplayProps {
   latticeA: LatticeState | null;
   latticeB: LatticeState | null;
   showArrows: boolean;
+  /** Per-cell pixel size used for the natural (unscaled) canvas resolution. */
   cellSize: number;
 }
+
+/** Floor on render resolution so small lattices still look crisp when zoomed. */
+const MIN_NATURAL_CELL = 16;
 
 export function DualSimulationDisplay({
   latticeA,
@@ -19,125 +24,28 @@ export function DualSimulationDisplay({
 }: DualSimulationDisplayProps) {
   const canvasARef = useRef<HTMLCanvasElement>(null);
   const canvasBRef = useRef<HTMLCanvasElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
 
-  // Calculate canvas dimensions based on lattice size
-  const [dimensions, setDimensions] = useState({
-    canvasWidth: latticeA ? latticeA.width * baseCellSize : 400,
-    canvasHeight: latticeA ? latticeA.height * baseCellSize : 400,
-    cellSize: baseCellSize,
-  });
+  // Render each lattice once at a fixed natural resolution; PanZoomCanvas owns
+  // fit-to-screen and any subsequent pan/zoom via a CSS transform.
+  const naturalCell = Math.max(baseCellSize, MIN_NATURAL_CELL);
 
-  // Calculate optimal dimensions to fill available space
-  const updateDimensions = useCallback(() => {
-    if (!containerRef.current || !latticeA) return;
-
-    const container = containerRef.current;
-    const containerRect = container.getBoundingClientRect();
-
-    // Validate container dimensions are reasonable
-    if (containerRect.width < 100 || containerRect.height < 100) {
-      return;
-    }
-
-    // Get the actual computed styles to account for padding
-    const containerStyles = window.getComputedStyle(container);
-    const containerPaddingH =
-      parseFloat(containerStyles.paddingLeft) + parseFloat(containerStyles.paddingRight);
-    const containerPaddingV =
-      parseFloat(containerStyles.paddingTop) + parseFloat(containerStyles.paddingBottom);
-
-    // Calculate available space accounting for container padding and gap
-    const gap = 8; // Gap between simulation containers
-    const labelHeight = 32; // Height for each simulation label
-    const containerBorder = 2; // Border width for each container
-    const containerPadding = 16; // Padding inside each container
-    const availableWidth = containerRect.width - containerPaddingH;
-    const availableHeight = containerRect.height - containerPaddingV;
-
-    // Each simulation container gets half the height minus gap
-    const containerHeight = (availableHeight - gap) / 2;
-    // Subtract label, borders, and padding from container height for canvas area
-    const effectiveHeightPerSimulation =
-      containerHeight - labelHeight - containerBorder * 2 - containerPadding * 2;
-    // Width accounting for container borders and padding
-    const effectiveWidth = availableWidth - containerBorder * 2 - containerPadding * 2;
-
-    // Calculate the optimal cell size to fit within viewport
-    // Use a higher factor to maximize space usage
-    const maxCellSizeByWidth = effectiveWidth / latticeA.width;
-    const maxCellSizeByHeight = effectiveHeightPerSimulation / latticeA.height;
-
-    // Choose the limiting dimension
-    const optimalCellSize = Math.min(maxCellSizeByWidth, maxCellSizeByHeight);
-
-    // Set minimum and maximum cell sizes
-    const MIN_CELL_SIZE = 8;
-    const MAX_CELL_SIZE = 80;
-
-    // Clamp the cell size within reasonable bounds
-    const finalCellSize = Math.floor(
-      Math.max(MIN_CELL_SIZE, Math.min(MAX_CELL_SIZE, optimalCellSize)),
-    );
-
-    // Calculate actual canvas dimensions
-    const canvasWidth = Math.floor(latticeA.width * finalCellSize);
-    const canvasHeight = Math.floor(latticeA.height * finalCellSize);
-
-    setDimensions({
-      canvasWidth,
-      canvasHeight,
-      cellSize: finalCellSize,
-    });
-  }, [latticeA]);
-
-  // Setup resize observer
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      // Only update if the container has meaningful dimensions
-      for (const entry of entries) {
-        if (entry.contentRect.width > 100 && entry.contentRect.height > 100) {
-          updateDimensions();
-        }
-      }
-    });
-
-    resizeObserver.observe(containerRef.current);
-
-    // Single update after DOM settles
-    const timeoutId = setTimeout(() => {
-      updateDimensions();
-    }, 10);
-
-    return () => {
-      clearTimeout(timeoutId);
-      resizeObserver.disconnect();
-    };
-  }, [updateDimensions]);
-
-  // Render simulation A
   useEffect(() => {
     if (!latticeA || !canvasARef.current) return;
-
     const renderer = new PathRenderer(canvasARef.current, {
-      cellSize: dimensions.cellSize,
+      cellSize: naturalCell,
       mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
     });
     renderer.render(latticeA);
-  }, [latticeA, showArrows, dimensions.cellSize]);
+  }, [latticeA, showArrows, naturalCell]);
 
-  // Render simulation B
   useEffect(() => {
     if (!latticeB || !canvasBRef.current) return;
-
     const renderer = new PathRenderer(canvasBRef.current, {
-      cellSize: dimensions.cellSize,
+      cellSize: naturalCell,
       mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
     });
     renderer.render(latticeB);
-  }, [latticeB, showArrows, dimensions.cellSize]);
+  }, [latticeB, showArrows, naturalCell]);
 
   if (!latticeA || !latticeB) {
     return (
@@ -147,37 +55,31 @@ export function DualSimulationDisplay({
     );
   }
 
+  // PathRenderer sizes its backing store to (N + 1) * cellSize (a half-cell
+  // margin around the lattice), so the wrapper must use the same dimensions for
+  // its fit/center math and not re-impose a different CSS size on the canvas.
+  const widthA = (latticeA.width + 1) * naturalCell;
+  const heightA = (latticeA.height + 1) * naturalCell;
+  const widthB = (latticeB.width + 1) * naturalCell;
+  const heightB = (latticeB.height + 1) * naturalCell;
+
   return (
-    <div className="dual-simulation-display" ref={containerRef}>
-      {/* Simulation A Container */}
+    <div className="dual-simulation-display">
       <div className="simulation-container">
         <div className="simulation-label">Simulation A</div>
         <div className="simulation-content">
-          <canvas
-            ref={canvasARef}
-            width={dimensions.canvasWidth}
-            height={dimensions.canvasHeight}
-            className="simulation-canvas"
-            style={{
-              display: 'block',
-            }}
-          />
+          <PanZoomCanvas width={widthA} height={heightA} fitMode="contain">
+            <canvas ref={canvasARef} className="simulation-canvas" />
+          </PanZoomCanvas>
         </div>
       </div>
 
-      {/* Simulation B Container */}
       <div className="simulation-container">
         <div className="simulation-label">Simulation B</div>
         <div className="simulation-content">
-          <canvas
-            ref={canvasBRef}
-            width={dimensions.canvasWidth}
-            height={dimensions.canvasHeight}
-            className="simulation-canvas"
-            style={{
-              display: 'block',
-            }}
-          />
+          <PanZoomCanvas width={widthB} height={heightB} fitMode="contain">
+            <canvas ref={canvasBRef} className="simulation-canvas" />
+          </PanZoomCanvas>
         </div>
       </div>
     </div>

--- a/client/src/components/PanZoomCanvas.css
+++ b/client/src/components/PanZoomCanvas.css
@@ -1,0 +1,149 @@
+.pan-zoom-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md, 0.5rem);
+  overflow: hidden;
+  box-sizing: border-box;
+  min-height: 0;
+  min-width: 0;
+}
+
+/* When used inside DualSimulationDisplay, drop the extra chrome. */
+.simulation-content .pan-zoom-container {
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+
+.pan-zoom-viewport {
+  flex: 1 1 0;
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+  min-height: 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.pan-zoom-content {
+  position: absolute;
+  will-change: transform;
+  pointer-events: auto;
+}
+
+.pan-zoom-content.initialized {
+  transition: transform 0.1s ease-out;
+}
+
+.pan-zoom-content.dragging {
+  transition: none;
+}
+
+.canvas-container {
+  position: relative;
+  display: block;
+}
+
+.canvas-container canvas {
+  position: absolute !important;
+  top: 0 !important;
+  left: 0 !important;
+  display: block !important;
+}
+
+.pan-zoom-controls {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+  background: var(--panel-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 0.375rem;
+  padding: 0.25rem;
+  box-shadow: var(--shadow-md, 0 2px 8px rgba(0, 0, 0, 0.1));
+  z-index: 10;
+}
+
+.control-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: 0.25rem;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.control-btn:hover {
+  background: var(--color-bg-tertiary);
+  color: var(--color-text-primary);
+  border-color: var(--color-primary);
+}
+
+.control-btn:active {
+  transform: scale(0.95);
+}
+
+.control-btn svg {
+  stroke-width: 2;
+}
+
+.zoom-indicator {
+  padding: 0 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  min-width: 3rem;
+  text-align: center;
+}
+
+.pan-zoom-label {
+  flex-shrink: 0;
+  height: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  background: var(--color-bg-primary);
+  border-bottom: 1px solid var(--color-border);
+  padding: 0.25rem 0.5rem;
+  order: -1; /* label above the viewport */
+}
+
+[data-theme='dark'] .pan-zoom-container {
+  background: var(--color-bg-tertiary);
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+  .pan-zoom-controls {
+    top: 0.25rem;
+    right: 0.25rem;
+    padding: 0.125rem;
+  }
+
+  .control-btn {
+    width: 24px;
+    height: 24px;
+  }
+
+  .zoom-indicator {
+    font-size: 0.7rem;
+    padding: 0 0.25rem;
+  }
+}

--- a/client/src/components/PanZoomCanvas.tsx
+++ b/client/src/components/PanZoomCanvas.tsx
@@ -1,0 +1,420 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import './PanZoomCanvas.css';
+
+interface PanZoomCanvasProps {
+  /** A single canvas element. Its width/height/style are managed by this wrapper. */
+  children: React.ReactElement<React.CanvasHTMLAttributes<HTMLCanvasElement>, 'canvas'>;
+  /** Natural (unscaled) pixel width of the canvas content. */
+  width: number;
+  /** Natural (unscaled) pixel height of the canvas content. */
+  height: number;
+  minZoom?: number;
+  maxZoom?: number;
+  enablePan?: boolean;
+  enableZoom?: boolean;
+  showControls?: boolean;
+  label?: string;
+  /** 'contain' fits the whole canvas with padding; 'fill' maximizes usage. */
+  fitMode?: 'contain' | 'fill';
+  /** Override the auto-computed initial scale. */
+  initialScale?: number;
+}
+
+/**
+ * Wraps a canvas in a pannable / zoomable viewport so large lattices (N≳32) stay
+ * legible. The canvas is rendered once at its natural resolution; this component
+ * applies a CSS transform for the view, and auto-fits the content to the viewport
+ * on mount, on resize, and when the canvas dimensions change.
+ *
+ * Keyboard: `f` fits to screen, `r` resets the view (ignored while typing).
+ */
+export function PanZoomCanvas({
+  children,
+  width,
+  height,
+  minZoom = 0.1,
+  maxZoom = 5,
+  enablePan = true,
+  enableZoom = true,
+  showControls = true,
+  label,
+  fitMode = 'fill',
+  initialScale,
+}: PanZoomCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [zoom, setZoom] = useState(1);
+  const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
+  const [lastPan, setLastPan] = useState({ x: 0, y: 0 });
+  const [isInitialized, setIsInitialized] = useState(false);
+  // Ref mirror so fitToScreen can fire the one-shot init without taking
+  // isInitialized as a dependency (which would churn the fit/resize effects).
+  const isInitializedRef = useRef(false);
+
+  // Mouse wheel zoom, anchored at the cursor.
+  const handleWheel = useCallback(
+    (e: WheelEvent) => {
+      if (!enableZoom) return;
+      e.preventDefault();
+
+      const viewport = containerRef.current?.querySelector('.pan-zoom-viewport');
+      if (!viewport) return;
+
+      const rect = viewport.getBoundingClientRect();
+      const mouseX = e.clientX - rect.left;
+      const mouseY = e.clientY - rect.top;
+
+      const delta = e.deltaY > 0 ? 0.9 : 1.1;
+      const newZoom = Math.min(Math.max(zoom * delta, minZoom), maxZoom);
+
+      // With transform-origin at 0 0, keep the point under the cursor fixed.
+      const canvasX = (mouseX - pan.x) / zoom;
+      const canvasY = (mouseY - pan.y) / zoom;
+      const newPanX = mouseX - canvasX * newZoom;
+      const newPanY = mouseY - canvasY * newZoom;
+
+      setZoom(newZoom);
+      setPan({ x: newPanX, y: newPanY });
+    },
+    [zoom, pan, minZoom, maxZoom, enableZoom],
+  );
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      if (!enablePan) return;
+      if (e.button !== 0) return; // Only left click
+
+      setIsDragging(true);
+      setDragStart({ x: e.clientX, y: e.clientY });
+      setLastPan(pan);
+      e.preventDefault();
+    },
+    [pan, enablePan],
+  );
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent) => {
+      if (!isDragging || !enablePan) return;
+
+      const deltaX = e.clientX - dragStart.x;
+      const deltaY = e.clientY - dragStart.y;
+
+      setPan({
+        x: lastPan.x + deltaX,
+        y: lastPan.y + deltaY,
+      });
+    },
+    [isDragging, dragStart, lastPan, enablePan],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setIsDragging(false);
+  }, []);
+
+  // Recenter the (newly scaled) canvas within the viewport.
+  const recenter = useCallback(
+    (newZoom: number) => {
+      const viewport = containerRef.current?.querySelector(
+        '.pan-zoom-viewport',
+      ) as HTMLElement | null;
+      if (!viewport) return;
+      const viewportWidth = viewport.offsetWidth || viewport.clientWidth;
+      const viewportHeight = viewport.offsetHeight || viewport.clientHeight;
+      setPan({
+        x: (viewportWidth - width * newZoom) / 2,
+        y: (viewportHeight - height * newZoom) / 2,
+      });
+    },
+    [width, height],
+  );
+
+  const zoomIn = useCallback(() => {
+    setZoom((z) => {
+      const newZoom = Math.min(z * 1.2, maxZoom);
+      recenter(newZoom);
+      return newZoom;
+    });
+  }, [maxZoom, recenter]);
+
+  const zoomOut = useCallback(() => {
+    setZoom((z) => {
+      const newZoom = Math.max(z / 1.2, minZoom);
+      recenter(newZoom);
+      return newZoom;
+    });
+  }, [minZoom, recenter]);
+
+  const fitToScreen = useCallback(() => {
+    const container = containerRef.current;
+    const viewport = container?.querySelector('.pan-zoom-viewport') as HTMLElement | null;
+    if (!container || !viewport) return;
+
+    // Prefer computed/bounding dimensions; fall back through offset/client/parent.
+    let containerWidth = 0;
+    let containerHeight = 0;
+
+    const rect = viewport.getBoundingClientRect();
+    if (rect.width > 0 && rect.height > 0) {
+      containerWidth = rect.width;
+      containerHeight = rect.height;
+    }
+    if (containerWidth <= 0 || containerHeight <= 0) {
+      if (viewport.clientWidth > 0 && viewport.clientHeight > 0) {
+        containerWidth = viewport.clientWidth;
+        containerHeight = viewport.clientHeight;
+      }
+    }
+    if (containerWidth <= 0 || containerHeight <= 0) {
+      const parentRect = container.getBoundingClientRect();
+      if (parentRect.width > 0 && parentRect.height > 0) {
+        containerWidth = parentRect.width - 20;
+        containerHeight = parentRect.height - 60; // account for controls/label
+      }
+    }
+
+    if (containerWidth <= 0 || containerHeight <= 0) return;
+
+    const padding = fitMode === 'fill' ? 2 : 10;
+    const availableWidth = containerWidth - padding * 2;
+    const availableHeight = containerHeight - padding * 2;
+
+    const scaleX = availableWidth / width;
+    const scaleY = availableHeight / height;
+    let scale =
+      fitMode === 'fill' ? Math.min(scaleX, scaleY) * 0.95 : Math.min(scaleX, scaleY) * 0.85;
+
+    if (initialScale !== undefined) {
+      scale = initialScale;
+    }
+    scale = Math.min(Math.max(scale, minZoom), maxZoom);
+
+    // transform-origin is top-left, so center by adjusting pan.
+    const panX = (containerWidth - width * scale) / 2;
+    const panY = (containerHeight - height * scale) / 2;
+
+    setZoom(scale);
+    setPan({ x: panX, y: panY });
+
+    if (!isInitializedRef.current) {
+      isInitializedRef.current = true;
+      setTimeout(() => setIsInitialized(true), 100);
+    }
+  }, [width, height, fitMode, initialScale, minZoom, maxZoom]);
+
+  const resetView = useCallback(() => {
+    fitToScreen();
+  }, [fitToScreen]);
+
+  // Wheel listener (non-passive so preventDefault works).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+    };
+  }, [handleWheel]);
+
+  // Release drag even if the mouse goes up outside the viewport.
+  useEffect(() => {
+    const handleGlobalMouseUp = () => setIsDragging(false);
+    window.addEventListener('mouseup', handleGlobalMouseUp);
+    return () => {
+      window.removeEventListener('mouseup', handleGlobalMouseUp);
+    };
+  }, []);
+
+  // Keyboard shortcuts: f = fit, r = reset (ignored while typing).
+  useEffect(() => {
+    const handleKeyPress = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      const target = e.target as HTMLElement;
+      if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') return;
+
+      if (e.key === 'f') {
+        e.preventDefault();
+        fitToScreen();
+      } else if (e.key === 'r') {
+        e.preventDefault();
+        resetView();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyPress);
+    return () => {
+      window.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [fitToScreen, resetView]);
+
+  // Fit on mount and whenever the canvas dimensions change, retrying until the
+  // viewport reports usable dimensions (layout may not have settled yet).
+  useEffect(() => {
+    let isMounted = true;
+    let attemptCount = 0;
+    const maxAttempts = 5;
+    let fitTimeout: ReturnType<typeof setTimeout>;
+
+    const attemptFit = () => {
+      if (!isMounted || attemptCount >= maxAttempts) return;
+      attemptCount++;
+
+      const viewport = containerRef.current?.querySelector(
+        '.pan-zoom-viewport',
+      ) as HTMLElement | null;
+      if (!viewport) return;
+
+      const hasValidDimensions = viewport.offsetWidth > 100 && viewport.offsetHeight > 100;
+      if (hasValidDimensions) {
+        requestAnimationFrame(() => {
+          if (isMounted) fitToScreen();
+        });
+      } else {
+        const delay = Math.min(100 * Math.pow(1.5, attemptCount), 2000);
+        fitTimeout = setTimeout(() => {
+          if (isMounted) attemptFit();
+        }, delay);
+      }
+    };
+
+    fitTimeout = setTimeout(() => attemptFit(), 50);
+
+    return () => {
+      isMounted = false;
+      clearTimeout(fitTimeout);
+    };
+  }, [fitToScreen, width, height]);
+
+  // Refit when the viewport itself resizes (debounced, ignores tiny changes).
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let lastWidth = 0;
+    let lastHeight = 0;
+    let resizeTimeout: ReturnType<typeof setTimeout>;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      clearTimeout(resizeTimeout);
+      for (const entry of entries) {
+        const { width: newWidth, height: newHeight } = entry.contentRect;
+        const widthChanged = Math.abs(newWidth - lastWidth) > 10;
+        const heightChanged = Math.abs(newHeight - lastHeight) > 10;
+        if ((widthChanged || heightChanged) && newWidth > 100 && newHeight > 100) {
+          lastWidth = newWidth;
+          lastHeight = newHeight;
+          resizeTimeout = setTimeout(() => {
+            requestAnimationFrame(() => fitToScreen());
+          }, 150);
+        }
+      }
+    });
+
+    const viewport = container.querySelector('.pan-zoom-viewport');
+    resizeObserver.observe(viewport ?? container);
+
+    return () => {
+      clearTimeout(resizeTimeout);
+      resizeObserver.disconnect();
+    };
+  }, [fitToScreen]);
+
+  const childStyle = children.props.style ?? {};
+
+  return (
+    <div className="pan-zoom-container" ref={containerRef}>
+      <div
+        className="pan-zoom-viewport"
+        onMouseDown={handleMouseDown}
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseLeave}
+        style={{
+          cursor: isDragging ? 'grabbing' : enablePan ? 'grab' : 'default',
+        }}
+      >
+        <div
+          className={`pan-zoom-content ${isDragging ? 'dragging' : ''} ${isInitialized ? 'initialized' : ''}`}
+          style={{
+            transform: `translate(${pan.x}px, ${pan.y}px) scale(${zoom})`,
+            transformOrigin: '0 0',
+            width: `${width}px`,
+            height: `${height}px`,
+          }}
+        >
+          <div
+            className="canvas-container"
+            style={{
+              position: 'relative',
+              width: `${width}px`,
+              height: `${height}px`,
+              display: 'block',
+            }}
+          >
+            {React.cloneElement(children, {
+              width,
+              height,
+              style: {
+                ...childStyle,
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                display: 'block',
+                width: `${width}px`,
+                height: `${height}px`,
+              },
+            })}
+          </div>
+        </div>
+      </div>
+
+      {label && <div className="pan-zoom-label">{label}</div>}
+
+      {showControls && (
+        <div className="pan-zoom-controls">
+          <button onClick={zoomIn} title="Zoom In" aria-label="Zoom in" className="control-btn">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35M11 8v6M8 11h6" />
+            </svg>
+          </button>
+          <button onClick={zoomOut} title="Zoom Out" aria-label="Zoom out" className="control-btn">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <circle cx="11" cy="11" r="8" />
+              <path d="m21 21-4.35-4.35M8 11h6" />
+            </svg>
+          </button>
+          <button
+            onClick={resetView}
+            title="Reset View (R key)"
+            aria-label="Reset view"
+            className="control-btn"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+            </svg>
+          </button>
+          <button
+            onClick={fitToScreen}
+            title="Fit to Screen (F key)"
+            aria-label="Fit to screen"
+            className="control-btn"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor">
+              <path d="M8 3H5a2 2 0 0 0-2 2v3m18 0V5a2 2 0 0 0-2-2h-3m0 18h3a2 2 0 0 0 2-2v-3M3 16v3a2 2 0 0 0 2 2h3" />
+            </svg>
+          </button>
+          <span className="zoom-indicator" aria-live="polite">
+            {Math.round(zoom * 100)}%
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/tests/pan-zoom-centering.test.ts
+++ b/client/tests/pan-zoom-centering.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for PanZoomCanvas centering logic
+ */
+
+describe('PanZoomCanvas Centering', () => {
+  describe('Centering Calculations', () => {
+    it('should center canvas correctly when scale is 1', () => {
+      const canvasWidth = 600;
+      const canvasHeight = 400;
+      const viewportWidth = 1000;
+      const viewportHeight = 800;
+      const scale = 1;
+
+      const scaledWidth = canvasWidth * scale;
+      const scaledHeight = canvasHeight * scale;
+      const panX = (viewportWidth - scaledWidth) / 2;
+      const panY = (viewportHeight - scaledHeight) / 2;
+
+      // Canvas should be centered
+      expect(panX).toBe(200); // (1000 - 600) / 2
+      expect(panY).toBe(200); // (800 - 400) / 2
+    });
+
+    it('should center canvas correctly when scale is less than 1', () => {
+      const canvasWidth = 800;
+      const canvasHeight = 600;
+      const viewportWidth = 600;
+      const viewportHeight = 400;
+      const scale = 0.5;
+
+      const scaledWidth = canvasWidth * scale;
+      const scaledHeight = canvasHeight * scale;
+      const panX = (viewportWidth - scaledWidth) / 2;
+      const panY = (viewportHeight - scaledHeight) / 2;
+
+      // Scaled canvas (400x300) should be centered in viewport (600x400)
+      expect(panX).toBe(100); // (600 - 400) / 2
+      expect(panY).toBe(50); // (400 - 300) / 2
+    });
+
+    it('should handle negative pan values when canvas is larger than viewport', () => {
+      const canvasWidth = 1200;
+      const canvasHeight = 900;
+      const viewportWidth = 800;
+      const viewportHeight = 600;
+      const scale = 1;
+
+      const scaledWidth = canvasWidth * scale;
+      const scaledHeight = canvasHeight * scale;
+      const panX = (viewportWidth - scaledWidth) / 2;
+      const panY = (viewportHeight - scaledHeight) / 2;
+
+      // When canvas is larger, pan values will be negative to center
+      expect(panX).toBe(-200); // (800 - 1200) / 2
+      expect(panY).toBe(-150); // (600 - 900) / 2
+    });
+
+    it('should calculate correct center position for typical simulation', () => {
+      // Typical values from the application
+      const canvasWidth = 480; // 24 cells * 20px
+      const canvasHeight = 480;
+      const viewportWidth = 797; // Typical viewport width
+      const viewportHeight = 318; // Typical viewport height per simulation
+      const scale = 0.66; // Scale to fit
+
+      const scaledWidth = canvasWidth * scale;
+      const scaledHeight = canvasHeight * scale;
+      const panX = (viewportWidth - scaledWidth) / 2;
+      const panY = (viewportHeight - scaledHeight) / 2;
+
+      // Should center the scaled canvas
+      expect(scaledWidth).toBeCloseTo(316.8);
+      expect(scaledHeight).toBeCloseTo(316.8);
+      expect(panX).toBeCloseTo(240.1); // (797 - 316.8) / 2
+      expect(panY).toBeCloseTo(0.6); // (318 - 316.8) / 2
+    });
+
+    it('should never produce the incorrect positions (164.5, 75.5)', () => {
+      // The bug was producing these specific incorrect values
+      const incorrectX = 164.5;
+
+      // Test various typical configurations
+      const configs = [
+        { canvas: 480, viewport: 797, scale: 1 },
+        { canvas: 480, viewport: 797, scale: 0.66 },
+        { canvas: 600, viewport: 800, scale: 0.9 },
+        { canvas: 400, viewport: 600, scale: 1 },
+      ];
+
+      for (const config of configs) {
+        const scaledWidth = config.canvas * config.scale;
+        const panX = (config.viewport - scaledWidth) / 2;
+
+        // Should never produce the incorrect value
+        expect(Math.abs(panX - incorrectX)).toBeGreaterThan(1);
+      }
+    });
+  });
+
+  describe('Viewport Dimension Validation', () => {
+    it('should validate viewport has positive dimensions', () => {
+      const hasValidDimensions = (width: number, height: number) => {
+        return width > 0 && height > 0;
+      };
+
+      expect(hasValidDimensions(800, 600)).toBe(true);
+      expect(hasValidDimensions(0, 600)).toBe(false);
+      expect(hasValidDimensions(800, 0)).toBe(false);
+      expect(hasValidDimensions(-100, 600)).toBe(false);
+    });
+
+    it('should use clientWidth/Height over getBoundingClientRect', () => {
+      // Mock element dimensions
+      const mockElement = {
+        clientWidth: 800,
+        clientHeight: 600,
+        getBoundingClientRect: () => ({
+          width: 750, // Different from clientWidth
+          height: 550, // Different from clientHeight
+        }),
+      };
+
+      // Should prefer clientWidth/Height
+      const width = mockElement.clientWidth || mockElement.getBoundingClientRect().width;
+      const height = mockElement.clientHeight || mockElement.getBoundingClientRect().height;
+
+      expect(width).toBe(800);
+      expect(height).toBe(600);
+    });
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-40.dev.6v.allison.la

## Summary
Adds a reusable `PanZoomCanvas` viewport so large lattices (N≳32) can be panned, zoomed, and auto-fit to the available space instead of rendering at a tiny fixed size. Both canvases in the dual-simulation display are now wrapped with it. Ported and cleaned from the original (closed) dual-simulation PR #33.

## Changes
- **`PanZoomCanvas` (new)** — wheel-zoom anchored at the cursor, drag-to-pan, zoom in/out/reset/fit-to-screen controls, and keyboard shortcuts (`f` = fit, `r` = reset; ignored while typing in inputs). Auto-fits on mount, on resize, and when the canvas dimensions change.
- **`DualSimulationDisplay`** — renders each lattice once at a fixed natural resolution and delegates fitting to `PanZoomCanvas`, replacing ~100 lines of bespoke `ResizeObserver`/dimension-fitting machinery it used to carry.
- **Theme-aware CSS** via design tokens (controls use `--panel-bg`); `aria-label`s on the control buttons and `aria-live` on the zoom indicator.
- **Tests** — ports the 7 pan-zoom centering tests from the #33 work.
- Cleanup vs the #33 source: removed the verbose `FitToScreen` `console.log` output and the `data-debug` attribute; fixed `NodeJS.Timeout` → `ReturnType<typeof setTimeout>`; consolidated duplicated recenter logic.

## Review fixes (from `code-review-architect` pass)
- **Dimension correctness:** `PathRenderer` sizes its backing store to `(N+1)·cellSize` (a half-cell margin), so the wrapper now uses the same `(N+1)·cell` dimensions for its fit/center math — eliminating a ~4–11% scale/squash error.
- **Effect hygiene:** moved the one-shot `isInitialized` flip to a ref so `fitToScreen` no longer takes it as a dependency (was churning the fit/resize effects after first fit).

## Testing
- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 22 suites / 289 tests pass
- [x] `npm run build` — OK
- [x] Manual: `/dual-simulation` renders centered & fit, controls work, square (uniform) lattice, no console errors

## Related Issues
Closes #38

## Checklist
- [x] Single concern (reusable pan/zoom viewport + adopt in dual display)
- [x] Code follows project conventions; no framework additions
- [x] Tests pass locally
- [x] CI checks pass
- [x] Preview link included

🤖 Generated with [Claude Code](https://claude.com/claude-code)
