### PR TITLE
Add a Content-Security-Policy to the deployed app — build-injected meta + CloudFront header policy (#43)

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -1,9 +1,51 @@
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
 import react from '@vitejs/plugin-react';
+
+// Content-Security-Policy for the deployed app. Notes on the allowances:
+// - script-src 'self'         — the production build emits only external module
+//                               scripts; there are no inline scripts.
+// - style-src 'unsafe-inline' — React sets inline `style` attributes (theme
+//                               variables, the pan/zoom transform), which require
+//                               this. Style injection is far lower-risk than script.
+// - worker-src 'self' blob:   — the Monte Carlo Web Worker (simulationWorker).
+// - img-src data:             — defensive, for any canvas/data-URI image use.
+// Header-only directives (frame-ancestors, HSTS, etc.) are NOT set here — they
+// are ignored in a <meta> CSP and would emit a console warning. They belong in
+// the CloudFront response-headers policy: see infrastructure/aws/.
+const CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "connect-src 'self'",
+  "worker-src 'self' blob:",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
+// Inject the CSP <meta> into the built index.html only. Build-only so Vite's dev
+// server (inline HMR scripts, eval, websocket) keeps working under `npm run dev`.
+function cspMetaPlugin(): Plugin {
+  return {
+    name: 'inject-csp-meta',
+    apply: 'build',
+    transformIndexHtml() {
+      return [
+        {
+          tag: 'meta',
+          attrs: { 'http-equiv': 'Content-Security-Policy', content: CSP },
+          injectTo: 'head-prepend',
+        },
+      ];
+    },
+  };
+}
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), cspMetaPlugin()],
   // Use root path for CloudFront/S3 deployment
   base: '/',
 });

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -29,6 +29,7 @@ CloudFront via OAC. There is no public bucket ACL and no S3 website endpoint.
 | `s3-bucket-policy-preview.json` | Same, for the preview bucket + preview distribution. | `aws s3api put-bucket-policy --bucket 6v-simulator-pr-previews` |
 | `cloudfront-spa-rewrite.js` | Viewer-request function: directory-index + SPA fallback to `/index.html`. | Production distribution. |
 | `pr-preview-router.js` | Viewer-request function: maps `pr-<N>.dev.6v.allison.la` → the `pr-<N>/` S3 prefix, with SPA fallback. | Preview distribution. |
+| `cloudfront-response-headers-policy.json` | Security headers — CSP (incl. `frame-ancestors`), HSTS, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`. | `aws cloudfront create-response-headers-policy --response-headers-policy-config file://cloudfront-response-headers-policy.json`, then attach the policy to both distributions' default cache behavior. |
 
 ## How a deploy works (driven by CI)
 
@@ -52,5 +53,12 @@ CloudFront via OAC. There is no public bucket ACL and no S3 website endpoint.
 - **No secrets in the repo.** The deploy identity's access key lives only in the
   GitHub Actions secrets (and should be mirrored to the team secret store). No
   credential values, and no account ID, are committed here.
+- **Security headers / CSP.** The app ships an active Content-Security-Policy as
+  a build-injected `<meta>` tag (see `client/vite.config.ts`). The stronger,
+  header-delivered version — adding `frame-ancestors`, HSTS, and MIME/framing
+  headers that a `<meta>` CSP cannot set — is in
+  `cloudfront-response-headers-policy.json`; apply it to both distributions to
+  supersede the meta tag.
 - **Hardening backlog.** Migrating CI auth from a long-lived IAM user key to
-  GitHub OIDC + an assumed IAM role would remove the static secret entirely.
+  GitHub OIDC + an assumed IAM role would remove the static secret entirely
+  (tracked in issue #42).

--- a/infrastructure/aws/cloudfront-response-headers-policy.json
+++ b/infrastructure/aws/cloudfront-response-headers-policy.json
@@ -1,0 +1,19 @@
+{
+  "Name": "6v-simulator-security-headers",
+  "Comment": "Security headers (CSP + HSTS + framing/MIME hardening) for the 6v-simulator distributions",
+  "SecurityHeadersConfig": {
+    "ContentSecurityPolicy": {
+      "Override": true,
+      "ContentSecurityPolicy": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self'; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'"
+    },
+    "StrictTransportSecurity": {
+      "Override": true,
+      "AccessControlMaxAgeSec": 31536000,
+      "IncludeSubdomains": true,
+      "Preload": false
+    },
+    "ContentTypeOptions": { "Override": true },
+    "FrameOptions": { "Override": true, "FrameOption": "DENY" },
+    "ReferrerPolicy": { "Override": true, "ReferrerPolicy": "strict-origin-when-cross-origin" }
+  }
+}


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-44.dev.6v.allison.la

## Summary
Adds a Content-Security-Policy as defense-in-depth against injected scripts, in two layers — one active immediately, one documented for the CloudFront operator.

## Changes
**1. Active now — build-injected `<meta>` CSP (`client/vite.config.ts`).**
A small Vite plugin injects the policy via `transformIndexHtml` with `apply: 'build'`, so it lands in the **production** `index.html` only and does **not** affect `npm run dev` (Vite's inline HMR scripts / `eval` / websocket keep working).

Policy:
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';
img-src 'self' data:; font-src 'self'; connect-src 'self';
worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'
```
- `script-src 'self'` with **no** inline/`unsafe-eval` allowance — the build emits only external module scripts.
- `style-src 'unsafe-inline'` is required by React inline `style` attributes (theme variables + the pan/zoom transform).
- `worker-src 'self' blob:` covers the Monte Carlo Web Worker.
- Header-only directives (`frame-ancestors`, HSTS, …) are intentionally omitted from the `<meta>` — browsers ignore them there and log a console warning.

**2. Documented for the operator — `infrastructure/aws/cloudfront-response-headers-policy.json`.**
The stronger header-delivered version that also sets `frame-ancestors 'none'`, HSTS, `X-Content-Type-Options`, `X-Frame-Options: DENY`, and `Referrer-Policy`. Applying it to both distributions supersedes the meta tag. README updated.

## Testing
Verified against the **built** app (`npm run preview`) in-browser:
- [x] **Zero CSP violations** on `/`, `/dual-simulation`, and across routes
- [x] Inline-style theming + the pan/zoom transform render correctly
- [x] Web Worker **constructs and round-trips a message** under `worker-src`
- [x] Dev server still serves `index.html` with **no** CSP (HMR intact)
- [x] typecheck / lint clean; 289 tests pass; build OK; policy JSON validates

## Related Issues
Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
