### PR TITLE
Prepare GitHub OIDC deploy auth (ready-to-apply, gated cutover) (#42)

### DIFF
--- a/docs/CI_OIDC_MIGRATION.md
+++ b/docs/CI_OIDC_MIGRATION.md
@@ -1,0 +1,103 @@
+# CI deploy auth: migrate to GitHub OIDC (issue #42)
+
+Goal: stop authenticating CI deploys with a long-lived IAM user access key
+(`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` secrets) and use short-lived
+GitHub OIDC + an assumed IAM role instead.
+
+This is a one-time cutover that requires an **AWS admin** (IAM `CreateRole` /
+`CreateOpenIDConnectProvider`) — it is intentionally **not** done by the CI
+identity and is **not** a change CI can apply on its own. The repo carries
+everything needed; the steps below are the only manual part.
+
+## Why this is a gated, two-part change
+
+The workflow edits in step 3 will **fail every deploy** until the IAM role from
+steps 1–2 exists. So the order matters: provision the role first, set the repo
+variable, *then* land the workflow edits, *then* remove the old key.
+
+## 1. Provision the OIDC provider + role (AWS admin)
+
+```bash
+cd infrastructure/aws
+AWS_PROFILE=<admin-profile> ./setup-github-oidc.sh
+```
+
+The script is idempotent. It creates (if absent) the
+`token.actions.githubusercontent.com` OIDC provider, creates the role
+`6v-simulator-github-deploy` with the trust policy in
+[`github-oidc-trust-policy.json`](../infrastructure/aws/github-oidc-trust-policy.json)
+(scoped to `repo:DavidAllison/6v-simulator:*`), attaches the existing
+least-privilege [`iam-deploy-policy.json`](../infrastructure/aws/iam-deploy-policy.json),
+and prints the **role ARN**.
+
+> Tightening option: restrict the trust `sub` to
+> `repo:DavidAllison/6v-simulator:ref:refs/heads/main` (production) plus
+> `repo:DavidAllison/6v-simulator:pull_request` (previews) instead of `:*`.
+
+## 2. Expose the role ARN to Actions
+
+```bash
+gh variable set AWS_DEPLOY_ROLE_ARN --body 'arn:aws:iam::<ACCOUNT_ID>:role/6v-simulator-github-deploy'
+```
+
+(A repo **variable**, not a secret — the ARN is not sensitive.)
+
+## 3. Switch the workflows to OIDC
+
+In **both** `.github/workflows/deploy-production.yml` and
+`.github/workflows/pr-preview.yml`:
+
+**a. Grant the job an OIDC token.** Add a job-level `permissions` block
+(`pr-preview.yml` already has one — add `id-token: write` to it):
+
+```yaml
+permissions:
+  id-token: write
+  contents: read          # pr-preview.yml also keeps: pull-requests: write, issues: write
+```
+
+**b. Add a credentials step** right after the build step, before the first
+`aws` call:
+
+```yaml
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: us-east-1
+```
+
+**c. Delete the per-step credential `env:` blocks.** Every step that currently
+carries
+
+```yaml
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: us-east-1
+```
+
+no longer needs it — the configure step exports credentials + region for the
+rest of the job. (Keep any non-credential `env` such as `AWS_DEFAULT_REGION` if
+a step relies on it, or set `aws-region` once via the configure step.)
+
+Land this as its own PR. Confirm a real deploy (push to `main`, and a test PR
+preview) succeeds via the assumed role.
+
+## 4. Remove the static key
+
+Once OIDC deploys are green:
+
+```bash
+gh secret delete AWS_ACCESS_KEY_ID
+gh secret delete AWS_SECRET_ACCESS_KEY
+# delete the access key on the old IAM user, and the user itself if unused
+aws iam list-access-keys --user-name <old-deploy-user>
+aws iam delete-access-key --user-name <old-deploy-user> --access-key-id <AKIA...>
+```
+
+## Acceptance criteria (from #42)
+
+- [ ] No long-lived AWS access key remains in repo secrets.
+- [ ] Production + PR-preview deploys succeed via the assumed role.
+- [ ] Role trust policy scoped to this repository.

--- a/infrastructure/aws/README.md
+++ b/infrastructure/aws/README.md
@@ -29,6 +29,8 @@ CloudFront via OAC. There is no public bucket ACL and no S3 website endpoint.
 | `s3-bucket-policy-preview.json` | Same, for the preview bucket + preview distribution. | `aws s3api put-bucket-policy --bucket 6v-simulator-pr-previews` |
 | `cloudfront-spa-rewrite.js` | Viewer-request function: directory-index + SPA fallback to `/index.html`. | Production distribution. |
 | `pr-preview-router.js` | Viewer-request function: maps `pr-<N>.dev.6v.allison.la` → the `pr-<N>/` S3 prefix, with SPA fallback. | Preview distribution. |
+| `github-oidc-trust-policy.json` | Trust policy for the GitHub OIDC deploy role (scoped to this repo). | Consumed by `setup-github-oidc.sh`. |
+| `setup-github-oidc.sh` | One-time, idempotent setup of the OIDC provider + deploy role so CI can drop the long-lived access key (issue #42). | Run by an AWS admin; see [`docs/CI_OIDC_MIGRATION.md`](../../docs/CI_OIDC_MIGRATION.md). |
 
 ## How a deploy works (driven by CI)
 
@@ -52,5 +54,9 @@ CloudFront via OAC. There is no public bucket ACL and no S3 website endpoint.
 - **No secrets in the repo.** The deploy identity's access key lives only in the
   GitHub Actions secrets (and should be mirrored to the team secret store). No
   credential values, and no account ID, are committed here.
-- **Hardening backlog.** Migrating CI auth from a long-lived IAM user key to
-  GitHub OIDC + an assumed IAM role would remove the static secret entirely.
+- **CI auth via OIDC (issue #42).** A ready-to-apply package to replace the
+  long-lived IAM user key with GitHub OIDC + an assumed role lives here
+  (`github-oidc-trust-policy.json`, `setup-github-oidc.sh`) with a runbook at
+  [`docs/CI_OIDC_MIGRATION.md`](../../docs/CI_OIDC_MIGRATION.md). The cutover
+  requires an AWS admin and is gated (the role must exist before the workflows
+  switch), so it is not applied automatically.

--- a/infrastructure/aws/github-oidc-trust-policy.json
+++ b/infrastructure/aws/github-oidc-trust-policy.json
@@ -1,0 +1,21 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GitHubActionsOIDC",
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:DavidAllison/6v-simulator:*"
+        }
+      }
+    }
+  ]
+}

--- a/infrastructure/aws/setup-github-oidc.sh
+++ b/infrastructure/aws/setup-github-oidc.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# One-time setup: let GitHub Actions deploy via OIDC instead of a long-lived
+# IAM access key (issue #42). Idempotent — safe to re-run.
+#
+# Requires AWS credentials with IAM admin (NOT the CI deploy key). Run by a
+# human/operator; this script never creates or prints a long-lived secret.
+#
+# After it prints the role ARN, finish the cutover (see
+# docs/CI_OIDC_MIGRATION.md): set the AWS_DEPLOY_ROLE_ARN repo variable, switch
+# the workflows to aws-actions/configure-aws-credentials with role-to-assume +
+# `permissions: id-token: write`, then delete the AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY secrets and the old IAM user's access key.
+#
+set -euo pipefail
+
+ROLE_NAME="${ROLE_NAME:-6v-simulator-github-deploy}"
+REPO="${REPO:-DavidAllison/6v-simulator}"
+PROVIDER_HOST="token.actions.githubusercontent.com"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ACCOUNT_ID="$(aws sts get-caller-identity --query Account --output text)"
+echo "Account: ${ACCOUNT_ID}  Repo: ${REPO}  Role: ${ROLE_NAME}"
+
+PROVIDER_ARN="arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${PROVIDER_HOST}"
+
+# 1. OIDC identity provider (create only if absent).
+if aws iam get-open-id-connect-provider --open-id-connect-provider-arn "${PROVIDER_ARN}" >/dev/null 2>&1; then
+  echo "OIDC provider already exists: ${PROVIDER_ARN}"
+else
+  echo "Creating OIDC provider ${PROVIDER_HOST} ..."
+  # Thumbprint is no longer validated by AWS for this provider, but the API still
+  # requires a value; this is GitHub's well-known intermediate CA thumbprint.
+  aws iam create-open-id-connect-provider \
+    --url "https://${PROVIDER_HOST}" \
+    --client-id-list "sts.amazonaws.com" \
+    --thumbprint-list "6938fd4d98bab03faadb97b34396831e3780aea1" >/dev/null
+fi
+
+# 2. Trust policy with the real account ID substituted in.
+TRUST_FILE="$(mktemp)"
+trap 'rm -f "${TRUST_FILE}"' EXIT
+sed "s/<ACCOUNT_ID>/${ACCOUNT_ID}/g" "${HERE}/github-oidc-trust-policy.json" > "${TRUST_FILE}"
+
+# 3. Role with that trust policy (create or update).
+if aws iam get-role --role-name "${ROLE_NAME}" >/dev/null 2>&1; then
+  echo "Updating trust policy on existing role ${ROLE_NAME} ..."
+  aws iam update-assume-role-policy --role-name "${ROLE_NAME}" --policy-document "file://${TRUST_FILE}"
+else
+  echo "Creating role ${ROLE_NAME} ..."
+  aws iam create-role --role-name "${ROLE_NAME}" \
+    --assume-role-policy-document "file://${TRUST_FILE}" \
+    --description "GitHub Actions OIDC deploy role for ${REPO}" >/dev/null
+fi
+
+# 4. Attach the least-privilege deploy permissions (same policy the CI key uses).
+aws iam put-role-policy --role-name "${ROLE_NAME}" \
+  --policy-name "6v-simulator-deploy" \
+  --policy-document "file://${HERE}/iam-deploy-policy.json"
+
+ROLE_ARN="arn:aws:iam::${ACCOUNT_ID}:role/${ROLE_NAME}"
+echo ""
+echo "Done. Role ARN:"
+echo "  ${ROLE_ARN}"
+echo ""
+echo "Next: gh variable set AWS_DEPLOY_ROLE_ARN --body '${ROLE_ARN}'"
+echo "Then switch the workflows to OIDC and remove the static access key"
+echo "(see docs/CI_OIDC_MIGRATION.md)."


### PR DESCRIPTION
## Summary
Lands a complete, **ready-to-apply** package to migrate CI deploy auth from a long-lived IAM user access key to short-lived **GitHub OIDC + an assumed role** — without changing the live workflows, so nothing breaks on merge.

This PR **prepares** the migration; it does not complete it. The actual cutover requires an AWS admin and is gated (the role must exist before the workflows switch), so issue #42 stays open until that's done.

## Changes (docs / IaC only — no app or workflow changes)
- **`infrastructure/aws/github-oidc-trust-policy.json`** — trust policy for the deploy role, scoped to `repo:DavidAllison/6v-simulator` (account ID kept out via an `<ACCOUNT_ID>` placeholder).
- **`infrastructure/aws/setup-github-oidc.sh`** — idempotent, admin-run setup of the OIDC provider + role; attaches the existing least-privilege `iam-deploy-policy.json`. Creates/prints **no** long-lived secret; emits the role ARN.
- **`docs/CI_OIDC_MIGRATION.md`** — the gated cutover runbook: exact workflow edits (`id-token: write` + `aws-actions/configure-aws-credentials` with `role-to-assume`, dropping the per-step key `env`), plus the final static-key teardown.
- README updated.

## Why gated, not automated
The cutover needs IAM `CreateRole` / `CreateOpenIDConnectProvider` on the deploy account — privileges the CI identity intentionally lacks. And the workflow edits would fail every deploy until the role exists. So: provision (admin) → set repo var → land workflow edits → delete key. The runbook spells this out.

## Testing
- [x] Trust-policy JSON validates
- [x] `bash -n setup-github-oidc.sh` clean
- [x] No app/workflow files touched → live deploys unaffected by this merge

## Related Issues
Refs #42 (stays open until the AWS-admin cutover lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
