### PR TITLE
feat: brand-grounded UI overhaul + dual-sim fixes (#48)

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/geist": "^5.2.9",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.8.1"
@@ -1362,6 +1363,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.9.tgz",
+      "integrity": "sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/client/package.json
+++ b/client/package.json
@@ -22,6 +22,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.9",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.8.1"

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -150,7 +150,10 @@
 
 .nav-link.active {
   color: var(--color-primary);
-  background: var(--color-primary-light);
+  /* Translucent tint over the page background keeps the active label readable in
+     both themes (solid --color-primary-light is near-primary in dark → low
+     contrast). */
+  background: color-mix(in srgb, var(--color-primary) 14%, transparent);
   border-bottom-color: var(--color-primary);
 }
 

--- a/client/src/components/DualSimulationDisplay.css
+++ b/client/src/components/DualSimulationDisplay.css
@@ -1,20 +1,21 @@
 .dual-simulation-display {
   width: 100%;
-  /* Concrete height so the two lattice canvases have room to render. The route
+  /* Side by side (as the heading promises) so both lattices are visible at once
+     and each box stays near-square — a square lattice then fills it instead of
+     floating in a wide, short letterbox. Concrete height because the route
      places this in normal page flow, so height:100% would collapse to ~0. */
-  height: min(78vh, 820px);
+  height: clamp(360px, 56vh, 620px);
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  flex-direction: row;
+  gap: 1rem;
   padding: 0.5rem;
   background: transparent;
   box-sizing: border-box;
-  min-height: 480px;
   overflow: hidden;
   position: relative;
 }
 
-/* Individual simulation container - exactly 50% height each */
+/* Individual simulation container - equal share of the row */
 .simulation-container {
   flex: 1 1 0; /* Each container takes equal space */
   display: flex;
@@ -24,6 +25,7 @@
   border-radius: 0.5rem;
   overflow: hidden;
   min-height: 0;
+  min-width: 0; /* allow shrink in the row layout */
   box-sizing: border-box;
   position: relative;
 }
@@ -94,11 +96,17 @@
   border-color: var(--color-border-dark);
 }
 
-/* Mobile responsive */
+/* Mobile responsive: stack the two simulations, since side-by-side is too narrow. */
 @media (max-width: 768px) {
   .dual-simulation-display {
-    gap: 0.25rem;
+    flex-direction: column;
+    height: auto;
+    gap: 0.5rem;
     padding: 0.25rem;
+  }
+
+  .simulation-container {
+    min-height: 320px;
   }
 
   .simulation-label {

--- a/client/src/components/DualSimulationDisplay.tsx
+++ b/client/src/components/DualSimulationDisplay.tsx
@@ -2,6 +2,8 @@ import { useRef, useEffect } from 'react';
 import type { LatticeState } from '../lib/six-vertex/types';
 import { PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
 import { RenderMode } from '../lib/six-vertex/types';
+import { getThemeColors } from '../lib/six-vertex/themeColors';
+import { useTheme } from '../hooks/useTheme';
 import { PanZoomCanvas } from './PanZoomCanvas';
 import './DualSimulationDisplay.css';
 
@@ -25,6 +27,13 @@ export function DualSimulationDisplay({
   const canvasARef = useRef<HTMLCanvasElement>(null);
   const canvasBRef = useRef<HTMLCanvasElement>(null);
 
+  // Theme-aware canvas colors so the lattices match the page in dark mode
+  // (otherwise they render on a stark white background). Depend on the boolean,
+  // not the freshly-built colors object, to avoid re-creating the renderer every
+  // render.
+  const { theme } = useTheme();
+  const isDark = theme === 'dark';
+
   // Render each lattice once at a fixed natural resolution; PanZoomCanvas owns
   // fit-to-screen and any subsequent pan/zoom via a CSS transform.
   const naturalCell = Math.max(baseCellSize, MIN_NATURAL_CELL);
@@ -34,18 +43,20 @@ export function DualSimulationDisplay({
     const renderer = new PathRenderer(canvasARef.current, {
       cellSize: naturalCell,
       mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
+      colors: getThemeColors(isDark),
     });
     renderer.render(latticeA);
-  }, [latticeA, showArrows, naturalCell]);
+  }, [latticeA, showArrows, naturalCell, isDark]);
 
   useEffect(() => {
     if (!latticeB || !canvasBRef.current) return;
     const renderer = new PathRenderer(canvasBRef.current, {
       cellSize: naturalCell,
       mode: showArrows ? RenderMode.Arrows : RenderMode.Paths,
+      colors: getThemeColors(isDark),
     });
     renderer.render(latticeB);
-  }, [latticeB, showArrows, naturalCell]);
+  }, [latticeB, showArrows, naturalCell, isDark]);
 
   if (!latticeA || !latticeB) {
     return (

--- a/client/src/lib/six-vertex/renderer/pathRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/pathRenderer.ts
@@ -370,7 +370,14 @@ export class PathRenderer {
   }
 
   /**
-   * Draw arrows on edges
+   * Draw arrows showing the flow direction on every edge.
+   *
+   * Each arrow is drawn directly from a vertex's `configuration` (the
+   * authoritative ice-rule in/out state, always present on both the standard and
+   * optimized engines) as a half-edge from the vertex centre to the edge
+   * midpoint. An `In` edge points toward the vertex; an `Out` edge points away.
+   * Reading the configuration directly keeps the arrows correct and live as the
+   * simulation steps, and avoids degenerate zero-length segments.
    */
   private drawArrows(state: LatticeState): void {
     // Use semi-transparent arrows when overlaying on paths
@@ -380,48 +387,33 @@ export class PathRenderer {
         : this.config.colors.arrow;
     this.ctx.fillStyle = this.ctx.strokeStyle;
     this.ctx.lineWidth = this.config.lineWidth;
+    this.ctx.setLineDash([]);
 
-    // Derive edge arrays from vertex configurations when the provided arrays are
-    // empty (e.g. states produced by the optimized simulation engine).
-    const { horizontalEdges, verticalEdges } = this.ensureEdges(state);
+    const cell = this.config.cellSize;
+    const half = cell / 2;
 
-    // Draw horizontal arrows
     for (let row = 0; row < state.height; row++) {
-      for (let col = 0; col <= state.width; col++) {
-        const edgeState = horizontalEdges[row][col];
-        if (edgeState !== undefined) {
-          const x1 = col * this.config.cellSize + this.config.cellSize / 2;
-          const x2 = (col + 1) * this.config.cellSize - this.config.cellSize / 2;
-          const y = (row + 1) * this.config.cellSize;
-
-          if (edgeState === EdgeState.In) {
-            // Arrow points right
-            this.drawArrow(x1, y, x2, y);
-          } else {
-            // Arrow points left
-            this.drawArrow(x2, y, x1, y);
-          }
-        }
-      }
-    }
-
-    // Draw vertical arrows
-    for (let row = 0; row <= state.height; row++) {
       for (let col = 0; col < state.width; col++) {
-        const edgeState = verticalEdges[row][col];
-        if (edgeState !== undefined) {
-          const x = (col + 1) * this.config.cellSize;
-          const y1 = row * this.config.cellSize + this.config.cellSize / 2;
-          const y2 = (row + 1) * this.config.cellSize - this.config.cellSize / 2;
+        const { configuration } = state.vertices[row][col];
+        const cx = (col + 1) * cell;
+        const cy = (row + 1) * cell;
 
-          if (edgeState === EdgeState.In) {
-            // Arrow points down
-            this.drawArrow(x, y1, x, y2);
-          } else {
-            // Arrow points up
-            this.drawArrow(x, y2, x, y1);
-          }
-        }
+        // For each edge: Out points away from the vertex, In points toward it.
+        // Right edge (horizontal, to the right of the vertex centre).
+        if (configuration.right === EdgeState.Out) this.drawArrow(cx, cy, cx + half, cy);
+        else this.drawArrow(cx + half, cy, cx, cy);
+
+        // Left edge.
+        if (configuration.left === EdgeState.Out) this.drawArrow(cx, cy, cx - half, cy);
+        else this.drawArrow(cx - half, cy, cx, cy);
+
+        // Top edge.
+        if (configuration.top === EdgeState.Out) this.drawArrow(cx, cy, cx, cy - half);
+        else this.drawArrow(cx, cy - half, cx, cy);
+
+        // Bottom edge.
+        if (configuration.bottom === EdgeState.Out) this.drawArrow(cx, cy, cx, cy + half);
+        else this.drawArrow(cx, cy + half, cx, cy);
       }
     }
   }

--- a/client/src/lib/six-vertex/renderer/pathRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/pathRenderer.ts
@@ -297,6 +297,79 @@ export class PathRenderer {
   }
 
   /**
+   * Return the opposite edge state (In <-> Out)
+   */
+  private oppositeOf(edge: EdgeState): EdgeState {
+    return edge === EdgeState.In ? EdgeState.Out : EdgeState.In;
+  }
+
+  /**
+   * Return populated horizontal/vertical edge arrays for the given state.
+   *
+   * The optimized simulation engine returns a LatticeState whose
+   * `horizontalEdges` / `verticalEdges` are empty (`[]`), with the full
+   * configuration carried only on `vertices[r][c].configuration`. When that is
+   * the case we reconstruct the edge arrays from the vertex configurations using
+   * the EXACT same convention the lattice builders use (see initialStates.ts):
+   *
+   *   vertex.left   = oppositeOf(horizontalEdges[r][c])
+   *   vertex.right  = horizontalEdges[r][c + 1]
+   *   vertex.top    = oppositeOf(verticalEdges[r][c])
+   *   vertex.bottom = verticalEdges[r + 1][c]
+   *
+   * Inverting those relations gives the edges below. Dimensions match the
+   * builders: horizontalEdges has `height` rows of `width + 1` entries,
+   * verticalEdges has `height + 1` rows of `width` entries.
+   */
+  private ensureEdges(state: LatticeState): {
+    horizontalEdges: EdgeState[][];
+    verticalEdges: EdgeState[][];
+  } {
+    const hasHorizontal =
+      state.horizontalEdges.length > 0 && state.horizontalEdges[0] !== undefined;
+    const hasVertical = state.verticalEdges.length > 0 && state.verticalEdges[0] !== undefined;
+
+    if (hasHorizontal && hasVertical) {
+      return {
+        horizontalEdges: state.horizontalEdges,
+        verticalEdges: state.verticalEdges,
+      };
+    }
+
+    const { width, height } = state;
+
+    const horizontalEdges: EdgeState[][] = Array.from(
+      { length: height },
+      () => new Array<EdgeState>(width + 1),
+    );
+    const verticalEdges: EdgeState[][] = Array.from(
+      { length: height + 1 },
+      () => new Array<EdgeState>(width),
+    );
+
+    for (let row = 0; row < height; row++) {
+      for (let col = 0; col < width; col++) {
+        const { configuration } = state.vertices[row][col];
+
+        // Right edge of (row,col) is the left edge of (row,col+1).
+        horizontalEdges[row][col + 1] = configuration.right;
+        // Bottom edge of (row,col) is the top edge of (row+1,col).
+        verticalEdges[row + 1][col] = configuration.bottom;
+
+        // Boundary edges derive from the inverse mapping.
+        if (col === 0) {
+          horizontalEdges[row][0] = this.oppositeOf(configuration.left);
+        }
+        if (row === 0) {
+          verticalEdges[0][col] = this.oppositeOf(configuration.top);
+        }
+      }
+    }
+
+    return { horizontalEdges, verticalEdges };
+  }
+
+  /**
    * Draw arrows on edges
    */
   private drawArrows(state: LatticeState): void {
@@ -308,10 +381,14 @@ export class PathRenderer {
     this.ctx.fillStyle = this.ctx.strokeStyle;
     this.ctx.lineWidth = this.config.lineWidth;
 
+    // Derive edge arrays from vertex configurations when the provided arrays are
+    // empty (e.g. states produced by the optimized simulation engine).
+    const { horizontalEdges, verticalEdges } = this.ensureEdges(state);
+
     // Draw horizontal arrows
     for (let row = 0; row < state.height; row++) {
       for (let col = 0; col <= state.width; col++) {
-        const edgeState = state.horizontalEdges[row][col];
+        const edgeState = horizontalEdges[row][col];
         if (edgeState !== undefined) {
           const x1 = col * this.config.cellSize + this.config.cellSize / 2;
           const x2 = (col + 1) * this.config.cellSize - this.config.cellSize / 2;
@@ -331,7 +408,7 @@ export class PathRenderer {
     // Draw vertical arrows
     for (let row = 0; row <= state.height; row++) {
       for (let col = 0; col < state.width; col++) {
-        const edgeState = state.verticalEdges[row][col];
+        const edgeState = verticalEdges[row][col];
         if (edgeState !== undefined) {
           const x = (col + 1) * this.config.cellSize;
           const y1 = row * this.config.cellSize + this.config.cellSize / 2;
@@ -653,6 +730,10 @@ export class PathRenderer {
     state: LatticeState,
     currentEdge: { row: number; col: number; type: 'horizontal' | 'vertical' },
   ): { row: number; col: number; type: 'horizontal' | 'vertical' } | null {
+    // Derive edge arrays from vertex configurations when the provided arrays are
+    // empty (e.g. states produced by the optimized simulation engine).
+    const { horizontalEdges, verticalEdges } = this.ensureEdges(state);
+
     // Determine which vertex this edge touches
     let vertexRow: number, vertexCol: number;
     let entryDirection: string;
@@ -670,7 +751,7 @@ export class PathRenderer {
         entryDirection = 'right';
       } else {
         // Interior edge - need to check arrow direction
-        const edgeState = state.horizontalEdges[currentEdge.row][currentEdge.col];
+        const edgeState = horizontalEdges[currentEdge.row][currentEdge.col];
         if (edgeState === EdgeState.In) {
           // Arrow points right, so we enter the vertex to the right
           vertexCol = currentEdge.col;
@@ -694,7 +775,7 @@ export class PathRenderer {
         entryDirection = 'bottom';
       } else {
         // Interior edge
-        const edgeState = state.verticalEdges[currentEdge.row][currentEdge.col];
+        const edgeState = verticalEdges[currentEdge.row][currentEdge.col];
         if (edgeState === EdgeState.In) {
           // Arrow points down
           vertexRow = currentEdge.row;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider } from './contexts/ThemeContext';
+import '@fontsource-variable/geist/index.css';
 import './index.css';
 import App from './App.tsx';
 

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -5,22 +5,22 @@
 /* Color Palette - Light Theme (Default) */
 :root {
   /* Primary Colors */
-  --color-primary: #0066cc;
-  --color-primary-hover: #0052a3;
-  --color-primary-light: #e6f2ff;
+  --color-primary: #7c3aed;
+  --color-primary-hover: #6d28d9;
+  --color-primary-light: #ede9fe;
 
   /* Neutral Colors */
   --color-bg-primary: #ffffff;
-  --color-bg-secondary: #f8f9fa;
-  --color-bg-tertiary: #e9ecef;
+  --color-bg-secondary: #f8fafc;
+  --color-bg-tertiary: #f1f5f9;
 
-  --color-text-primary: #212529;
-  --color-text-secondary: #6c757d;
-  --color-text-muted: #adb5bd;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #475569;
+  --color-text-muted: #94a3b8;
   --color-text-inverse: #ffffff;
 
-  --color-border: #dee2e6;
-  --color-border-light: #e9ecef;
+  --color-border: #e2e8f0;
+  --color-border-light: #f1f5f9;
 
   /* Shadows */
   --color-shadow: rgba(0, 0, 0, 0.1);
@@ -58,6 +58,7 @@
   --font-family-base:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell',
     'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  --font-family-heading: 'Geist Variable', 'Geist', system-ui, -apple-system, sans-serif;
   --font-family-mono: 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Code', monospace;
 
   /* Type scale (~1.2 modular scale) */
@@ -110,19 +111,19 @@
   --color-scrim: rgba(0, 0, 0, 0.5);
 
   /* Hover states */
-  --color-bg-hover: #f5f5f5;
-  --color-border-hover: #bbb;
-  --color-bg-active: #e5e7eb;
+  --color-bg-hover: #f1f5f9;
+  --color-border-hover: #cbd5e1;
+  --color-bg-active: #e2e8f0;
   --color-shadow-hover: rgba(0, 0, 0, 0.15);
 
   /* Scrollbar */
-  --color-scrollbar-thumb: #888;
-  --color-scrollbar-thumb-hover: #555;
+  --color-scrollbar-thumb: #94a3b8;
+  --color-scrollbar-thumb-hover: #64748b;
 
   /* Surfaces (aliases used by route panels) */
   --panel-bg: var(--color-bg-secondary);
-  --color-bg-quaternary: #dde1e6;
-  --color-border-dark: #ced4da;
+  --color-bg-quaternary: #e2e8f0;
+  --color-border-dark: #cbd5e1;
 
   /* Vertex-type palette (Okabe–Ito, CVD-safe). Single source of truth shared
      with the Canvas via src/lib/six-vertex/themeColors.ts — keep in sync. */
@@ -137,22 +138,22 @@
 /* Dark Theme */
 [data-theme='dark'] {
   /* Primary Colors */
-  --color-primary: #4da3ff;
-  --color-primary-hover: #6bb1ff;
-  --color-primary-light: #1a3a52;
+  --color-primary: #a78bfa;
+  --color-primary-hover: #c4b5fd;
+  --color-primary-light: #2e1065;
 
   /* Neutral Colors */
-  --color-bg-primary: #1a1a1a;
-  --color-bg-secondary: #2d2d2d;
-  --color-bg-tertiary: #404040;
+  --color-bg-primary: #0f172a;
+  --color-bg-secondary: #1e293b;
+  --color-bg-tertiary: #334155;
 
-  --color-text-primary: #e0e0e0;
-  --color-text-secondary: #a0a0a0;
-  --color-text-muted: #707070;
+  --color-text-primary: #f1f5f9;
+  --color-text-secondary: #94a3b8;
+  --color-text-muted: #64748b;
   --color-text-inverse: #1a1a1a;
 
-  --color-border: #404040;
-  --color-border-light: #333333;
+  --color-border: #334155;
+  --color-border-light: #1e293b;
 
   /* Shadows */
   --color-shadow: rgba(0, 0, 0, 0.3);
@@ -178,27 +179,27 @@
 
   /* Semantic surfaces / elevation (page bg is #1a1a1a; raised is lighter) */
   --surface-base: var(--color-bg-primary);
-  --surface-raised: #242424;
-  --surface-sunken: #151515;
-  --surface-overlay: #242424;
+  --surface-raised: #1e293b;
+  --surface-sunken: #0b1220;
+  --surface-overlay: #1e293b;
 
   /* Scrim / overlay backdrop */
   --color-scrim: rgba(0, 0, 0, 0.7);
 
   /* Hover states */
-  --color-bg-hover: #3a3a3a;
-  --color-border-hover: #606060;
-  --color-bg-active: #454545;
+  --color-bg-hover: #334155;
+  --color-border-hover: #475569;
+  --color-bg-active: #475569;
   --color-shadow-hover: rgba(0, 0, 0, 0.4);
 
   /* Scrollbar */
-  --color-scrollbar-thumb: #606060;
-  --color-scrollbar-thumb-hover: #808080;
+  --color-scrollbar-thumb: #475569;
+  --color-scrollbar-thumb-hover: #64748b;
 
   /* Surfaces */
   --panel-bg: var(--color-bg-secondary);
-  --color-bg-quaternary: #505050;
-  --color-border-dark: #2a2a2a;
+  --color-bg-quaternary: #475569;
+  --color-border-dark: #1e293b;
 
   /* Vertex-type palette (brightened for the dark background) */
   --vertex-a1: #ff7d3b;
@@ -259,6 +260,7 @@ h3,
 h4,
 h5,
 h6 {
+  font-family: var(--font-family-heading);
   font-weight: var(--font-weight-semibold);
   line-height: var(--line-height-tight);
   color: var(--color-text-primary);

--- a/client/tests/six-vertex/arrowRendering.test.ts
+++ b/client/tests/six-vertex/arrowRendering.test.ts
@@ -181,11 +181,10 @@ describe('arrow rendering with empty edge arrays (optimized engine states)', () 
     //   top    = oppositeOf(verticalEdges[r][c])       -> V[0][c]     = oppositeOf(top)
     //   bottom = verticalEdges[r + 1][c]               -> V[r + 1][c] = bottom
     //
-    // Note: DWBC vertex configurations are per-vertex Fig.1 configs and are NOT
-    // globally edge-consistent between neighbors (a vertex's left edge does not
-    // generally equal oppositeOf its left neighbor's right edge). So we verify
-    // each edge against the SOURCE vertex the inverse derives it from, not a
-    // round-trip through all four edges of every vertex.
+    // We verify each reconstructed edge against the SOURCE vertex the inverse
+    // derives it from (each vertex's own right/bottom, and boundary left/top),
+    // which is exactly what ensureEdges consumes — rather than round-tripping
+    // through all four edges of every vertex.
     const reference = generateDWBCLow(6);
     const stripped = withEmptyEdges(reference);
 

--- a/client/tests/six-vertex/arrowRendering.test.ts
+++ b/client/tests/six-vertex/arrowRendering.test.ts
@@ -44,8 +44,8 @@ class MockCanvasContext {
   strokeRect(): void {}
   beginPath(): void {}
   closePath(): void {}
-  moveTo(): void {}
-  lineTo(): void {}
+  moveTo(_x?: number, _y?: number): void {}
+  lineTo(_x?: number, _y?: number): void {}
   quadraticCurveTo(): void {}
   bezierCurveTo(): void {}
   arc(): void {}
@@ -86,6 +86,37 @@ function withEmptyEdges(state: LatticeState): LatticeState {
 
 const oppositeOf = (e: EdgeState): EdgeState => (e === EdgeState.In ? EdgeState.Out : EdgeState.In);
 
+/**
+ * Recording context that captures every line segment (moveTo -> lineTo) so tests
+ * can assert what was actually drawn. Used to lock the arrow geometry: arrows
+ * must be non-degenerate and must reflect the per-vertex configuration.
+ */
+class RecordingContext extends MockCanvasContext {
+  segments: Array<{ x1: number; y1: number; x2: number; y2: number }> = [];
+  private cx = 0;
+  private cy = 0;
+  override moveTo(x = 0, y = 0): void {
+    this.cx = x;
+    this.cy = y;
+  }
+  override lineTo(x = 0, y = 0): void {
+    this.segments.push({ x1: this.cx, y1: this.cy, x2: x, y2: y });
+    this.cx = x;
+    this.cy = y;
+  }
+}
+
+class RecordingCanvas extends MockCanvas {
+  override context: RecordingContext;
+  constructor() {
+    super();
+    this.context = new RecordingContext(this);
+  }
+  override getContext(type: string): RecordingContext | null {
+    return type === '2d' ? this.context : null;
+  }
+}
+
 describe('arrow rendering with empty edge arrays (optimized engine states)', () => {
   it('does not throw in Arrows mode for a DWBC High state with empty edges', () => {
     const { renderer } = makeRenderer({ mode: RenderMode.Arrows });
@@ -105,6 +136,41 @@ describe('arrow rendering with empty edge arrays (optimized engine states)', () 
   it('still renders Arrows mode when edge arrays are populated', () => {
     const { renderer } = makeRenderer({ mode: RenderMode.Arrows });
     expect(() => renderer.render(generateDWBCHigh(8))).not.toThrow();
+  });
+
+  // --- Regression: arrows must reflect state and not be degenerate ---------
+  // A prior bug computed horizontal arrow endpoints as
+  //   x1 = col*cell + cell/2,  x2 = (col+1)*cell - cell/2  (== x1)
+  // so every arrow was a zero-length segment that drawArrow() rendered as a
+  // fixed-orientation arrowhead, identical for every edge regardless of In/Out.
+  // Result: a uniform arrow field that never changed as the simulation stepped.
+  function renderArrowSegments(state: LatticeState) {
+    const canvas = new RecordingCanvas();
+    const renderer = new PathRenderer(canvas as unknown as HTMLCanvasElement, {
+      mode: RenderMode.Arrows,
+      cellSize: 20,
+    });
+    renderer.render(state);
+    return canvas.context.segments;
+  }
+
+  it('draws non-degenerate arrow shafts (not zero-length segments)', () => {
+    const segments = renderArrowSegments(withEmptyEdges(generateDWBCHigh(8)));
+    const nonDegenerate = segments.filter((s) => s.x1 !== s.x2 || s.y1 !== s.y2);
+    expect(nonDegenerate.length).toBeGreaterThan(0);
+    // There must be genuinely horizontal shafts (y constant, x varying) and
+    // vertical shafts (x constant, y varying) — the degenerate bug had neither.
+    expect(segments.some((s) => s.y1 === s.y2 && Math.abs(s.x1 - s.x2) > 1)).toBe(true);
+    expect(segments.some((s) => s.x1 === s.x2 && Math.abs(s.y1 - s.y2) > 1)).toBe(true);
+  });
+
+  it('produces different arrows for different configurations (not a frozen field)', () => {
+    const high = renderArrowSegments(withEmptyEdges(generateDWBCHigh(8)));
+    const low = renderArrowSegments(withEmptyEdges(generateDWBCLow(8)));
+    const key = (segs: typeof high) => segs.map((s) => `${s.x1},${s.y1},${s.x2},${s.y2}`).join('|');
+    // DWBC High and Low have different vertex configurations, so their arrow
+    // fields must differ. The degenerate bug rendered both identically.
+    expect(key(high)).not.toBe(key(low));
   });
 
   it('reconstructs edges via the canonical inverse mapping from initialStates.ts', () => {

--- a/client/tests/six-vertex/arrowRendering.test.ts
+++ b/client/tests/six-vertex/arrowRendering.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Regression tests for arrow rendering against lattice states whose edge arrays
+ * are empty (as produced by the optimized simulation engine consumed by the
+ * dual-simulation view). The renderer must reconstruct the edges from the
+ * vertex configurations instead of crashing with
+ * "Cannot read properties of undefined (reading '0')".
+ *
+ * Repro: toggling "Show Arrows" on /dual-simulation. The optimized engine's
+ * getState() returns horizontalEdges: [] / verticalEdges: [] with the full
+ * configuration carried only on vertices[r][c].configuration.
+ */
+
+import { PathRenderer } from '../../src/lib/six-vertex/renderer/pathRenderer';
+import { generateDWBCHigh, generateDWBCLow } from '../../src/lib/six-vertex/initialStates';
+import { RenderMode, EdgeState } from '../../src/lib/six-vertex/types';
+import type { LatticeState, VertexConfiguration } from '../../src/lib/six-vertex/types';
+
+/**
+ * Minimal canvas mock with a back-reference so renderers that read
+ * ctx.canvas.{width,height} (e.g. paperStyleRenderer) work. Mirrors the mock in
+ * rendering.test.ts; the global jest setup mock omits the canvas back-reference.
+ */
+class MockCanvasContext {
+  canvas: MockCanvas;
+  fillStyle = '#000000';
+  strokeStyle = '#000000';
+  lineWidth = 1;
+  globalAlpha = 1;
+  font = '12px sans-serif';
+  textAlign = 'left';
+  textBaseline = 'alphabetic';
+  lineCap = 'butt';
+  lineJoin = 'miter';
+
+  constructor(canvas: MockCanvas) {
+    this.canvas = canvas;
+  }
+
+  save(): void {}
+  restore(): void {}
+  setLineDash(): void {}
+  clearRect(): void {}
+  fillRect(): void {}
+  strokeRect(): void {}
+  beginPath(): void {}
+  closePath(): void {}
+  moveTo(): void {}
+  lineTo(): void {}
+  quadraticCurveTo(): void {}
+  bezierCurveTo(): void {}
+  arc(): void {}
+  fill(): void {}
+  stroke(): void {}
+  fillText(): void {}
+  translate(): void {}
+  scale(): void {}
+}
+
+class MockCanvas {
+  width = 400;
+  height = 400;
+  context: MockCanvasContext;
+
+  constructor() {
+    this.context = new MockCanvasContext(this);
+  }
+
+  getContext(type: string): MockCanvasContext | null {
+    return type === '2d' ? this.context : null;
+  }
+}
+
+function makeRenderer(config?: Parameters<typeof PathRenderer.prototype.updateConfig>[0]) {
+  const canvas = new MockCanvas();
+  const renderer = new PathRenderer(canvas as unknown as HTMLCanvasElement, config);
+  return { canvas, renderer };
+}
+
+/**
+ * Produce a copy of a lattice state with EMPTY edge arrays, mimicking the
+ * optimized engine's getState() output (vertices populated, edges = []).
+ */
+function withEmptyEdges(state: LatticeState): LatticeState {
+  return { ...state, horizontalEdges: [], verticalEdges: [] };
+}
+
+const oppositeOf = (e: EdgeState): EdgeState => (e === EdgeState.In ? EdgeState.Out : EdgeState.In);
+
+describe('arrow rendering with empty edge arrays (optimized engine states)', () => {
+  it('does not throw in Arrows mode for a DWBC High state with empty edges', () => {
+    const { renderer } = makeRenderer({ mode: RenderMode.Arrows });
+    expect(() => renderer.render(withEmptyEdges(generateDWBCHigh(8)))).not.toThrow();
+  });
+
+  it('does not throw in Arrows mode for a DWBC Low state with empty edges', () => {
+    const { renderer } = makeRenderer({ mode: RenderMode.Arrows });
+    expect(() => renderer.render(withEmptyEdges(generateDWBCLow(8)))).not.toThrow();
+  });
+
+  it('does not throw in Both mode (paths + arrows) with empty edges', () => {
+    const { renderer } = makeRenderer({ mode: RenderMode.Both });
+    expect(() => renderer.render(withEmptyEdges(generateDWBCLow(8)))).not.toThrow();
+  });
+
+  it('still renders Arrows mode when edge arrays are populated', () => {
+    const { renderer } = makeRenderer({ mode: RenderMode.Arrows });
+    expect(() => renderer.render(generateDWBCHigh(8))).not.toThrow();
+  });
+
+  it('reconstructs edges via the canonical inverse mapping from initialStates.ts', () => {
+    // The reconstruction is the exact inverse of the forward mapping the lattice
+    // builders use (initialStates.ts ~L136-141):
+    //   left   = oppositeOf(horizontalEdges[r][c])     -> H[r][0]     = oppositeOf(left)
+    //   right  = horizontalEdges[r][c + 1]             -> H[r][c + 1] = right
+    //   top    = oppositeOf(verticalEdges[r][c])       -> V[0][c]     = oppositeOf(top)
+    //   bottom = verticalEdges[r + 1][c]               -> V[r + 1][c] = bottom
+    //
+    // Note: DWBC vertex configurations are per-vertex Fig.1 configs and are NOT
+    // globally edge-consistent between neighbors (a vertex's left edge does not
+    // generally equal oppositeOf its left neighbor's right edge). So we verify
+    // each edge against the SOURCE vertex the inverse derives it from, not a
+    // round-trip through all four edges of every vertex.
+    const reference = generateDWBCLow(6);
+    const stripped = withEmptyEdges(reference);
+
+    const renderer = new PathRenderer(new MockCanvas() as unknown as HTMLCanvasElement, {
+      mode: RenderMode.Arrows,
+    });
+    const ensureEdges = (
+      renderer as unknown as {
+        ensureEdges(s: LatticeState): {
+          horizontalEdges: EdgeState[][];
+          verticalEdges: EdgeState[][];
+        };
+      }
+    ).ensureEdges.bind(renderer);
+
+    const { horizontalEdges, verticalEdges } = ensureEdges(stripped);
+
+    // Dimensions follow the canonical builder convention.
+    expect(horizontalEdges.length).toBe(reference.height);
+    expect(horizontalEdges[0].length).toBe(reference.width + 1);
+    expect(verticalEdges.length).toBe(reference.height + 1);
+    expect(verticalEdges[0].length).toBe(reference.width);
+
+    for (let row = 0; row < reference.height; row++) {
+      for (let col = 0; col < reference.width; col++) {
+        const cfg: VertexConfiguration = reference.vertices[row][col].configuration;
+        // Each vertex's RIGHT and BOTTOM edges are derived directly from it.
+        expect(horizontalEdges[row][col + 1]).toBe(cfg.right);
+        expect(verticalEdges[row + 1][col]).toBe(cfg.bottom);
+        // Boundary LEFT/TOP edges are the oppositeOf the boundary vertex's edge.
+        if (col === 0) {
+          expect(horizontalEdges[row][0]).toBe(oppositeOf(cfg.left));
+        }
+        if (row === 0) {
+          expect(verticalEdges[0][col]).toBe(oppositeOf(cfg.top));
+        }
+      }
+    }
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-49.dev.6v.allison.la

## Summary
A brand-grounded modernization of the simulator plus three concrete dual-simulation bug fixes. The whole UI now follows the LMNTL brand system, the "Compare High vs Low" page is laid out side by side as its heading promises, and the **Show Arrows** feature — which previously crashed, then rendered a frozen/uniform field — now shows correct, live, theme-aware arrows.

## Changes

### Dual-simulation fixes
- **Show Arrows crash fixed.** The optimized engine returns empty `horizontalEdges`/`verticalEdges`, so `drawArrows`/path-tracing indexed `undefined` and tripped the ErrorBoundary. Added `ensureEdges()` to reconstruct edges from each vertex's `configuration` (exact inverse of the `initialStates` forward mapping) when the arrays are empty.
- **Arrows now reflect live state.** `drawArrows` had degenerate geometry — horizontal endpoints `x1 = col*cell + cell/2` and `x2 = (col+1)*cell - cell/2` are equal, so every arrow was a zero-length segment drawn as a fixed-orientation arrowhead, identical for every edge regardless of In/Out. Rewrote it to draw each edge directly from `vertex.configuration` (centre → edge midpoint). Arrows now show real mixed directions and update every frame.
- **Side-by-side layout.** The page heading says "two simulations side by side", but the CSS stacked them (`flex-direction: column`), producing wide, short letterboxes with a small lattice floating high and Simulation B below the fold. Switched to a row layout (stacked only on narrow screens) and near-square boxes so the lattice fills and centres.
- **Theme-aware canvases.** The dual-sim canvases always rendered on white; now they use `getThemeColors()` like the main simulator.

### Brand identity (LMNTL)
- Primary color → LMNTL purple (`#7c3aed` light / `#a78bfa` dark) on nav, buttons, sliders, focus rings, heading accents.
- Neutrals → slate scale; headings → **Geist Sans**, self-hosted via `@fontsource-variable/geist` so the build-time CSP (`font-src 'self'`) stays satisfied.
- **Preserved byte-for-byte:** the Okabe–Ito CVD-safe vertex palette and all status/semantic colors.

## Testing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (no new warnings)
- [x] `npx jest` — 296/296 tests pass, incl. new arrow regression tests (non-degenerate shafts; different configs → different arrow fields)
- [x] `npm run build` succeeds (Geist self-hosted in output; CSP intact)
- [x] Manual verification in light + dark on Simulator and dual-simulation; arrows confirmed animating (12/12 distinct frames during a run, was 1/1 frozen)
- [x] Console-error sweep across all routes — clean
- [ ] Preview deployment tested

## Related Issues
Fixes #48

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated
- [x] CI checks pass
- [ ] Preview link included and tested
