### PR TITLE
fix: nav alignment, main-canvas visibility, dual-sim sizing (#50)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -49,9 +49,16 @@ function App() {
 
           <nav className="header-nav" aria-label="Primary">
             <div className="nav-group nav-group--primary">
-              <NavLink to="/" className="nav-link" end>
-                Simulator
-              </NavLink>
+              {/* Blank label keeps this group the same height as the labelled
+                  groups so every nav link aligns on a common row. */}
+              <span className="nav-group__label" aria-hidden="true">
+                &nbsp;
+              </span>
+              <div className="nav-group__items">
+                <NavLink to="/" className="nav-link" end>
+                  Simulator
+                </NavLink>
+              </div>
             </div>
 
             <div className="nav-group">

--- a/client/src/components/PanZoomCanvas.tsx
+++ b/client/src/components/PanZoomCanvas.tsx
@@ -186,7 +186,7 @@ export function PanZoomCanvas({
     const scaleX = availableWidth / width;
     const scaleY = availableHeight / height;
     let scale =
-      fitMode === 'fill' ? Math.min(scaleX, scaleY) * 0.95 : Math.min(scaleX, scaleY) * 0.85;
+      fitMode === 'fill' ? Math.min(scaleX, scaleY) * 0.95 : Math.min(scaleX, scaleY) * 0.92;
 
     if (initialScale !== undefined) {
       scale = initialScale;

--- a/client/src/components/VisualizationCanvas.css
+++ b/client/src/components/VisualizationCanvas.css
@@ -4,11 +4,19 @@
   border-radius: 12px;
   box-shadow: var(--shadow-md);
   border: 1px solid var(--color-border);
-  position: relative;
   overflow: hidden;
   display: flex;
   flex-direction: column;
   transition: all var(--transition-base);
+  /* The side control/stats panels are tall; without this the grid stretches the
+     canvas column to match them and the centered lattice falls below the fold.
+     Cap to the viewport and stick so the figure stays visible while the controls
+     scroll. align-self:start opts out of the grid's stretch. */
+  align-self: start;
+  position: sticky;
+  top: 0.5rem;
+  max-height: calc(100vh - 5.5rem);
+  min-height: 420px;
 }
 
 .canvas-wrapper {

--- a/client/src/components/VisualizationCanvas.tsx
+++ b/client/src/components/VisualizationCanvas.tsx
@@ -116,9 +116,12 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
     const canvasWidth = (latticeState.width + 1) * cellSize;
     const canvasHeight = (latticeState.height + 1) * cellSize;
 
-    const scaleX = (containerRect.width - 100) / canvasWidth;
-    const scaleY = (containerRect.height - 100) / canvasHeight;
-    const newZoom = Math.min(scaleX, scaleY, 1);
+    // Fit to the container with a small margin, scaling UP for small lattices so
+    // they fill the figure area instead of sitting tiny (capped to keep large
+    // lattices crisp).
+    const scaleX = (containerRect.width - 48) / canvasWidth;
+    const scaleY = (containerRect.height - 48) / canvasHeight;
+    const newZoom = Math.min(Math.max(Math.min(scaleX, scaleY), 0.25), 4);
 
     setZoom(newZoom);
     setPan({ x: 0, y: 0 });


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-51.dev.6v.allison.la

## Summary
Visual-alignment polish following the brand overhaul: the top-bar nav links now share a common row, the main simulator's lattice stays visible and well-sized on load (instead of tiny and below the fold), and the dual-sim matrices fill their boxes a little more.

## Changes
- **Top nav** — the standalone "Simulator" link sat ~10px higher than the grouped links (which sit under "Learn"/"Developer" category labels). Gave the primary group a matching blank, `aria-hidden` label + items wrapper so every nav link aligns on one row. Verified: all links now share `top=29, center-y=44`.
- **Main canvas** — the tall left control panel stretched the canvas grid column, centering the lattice ~570px down (below the fold), and the auto-fit was capped at 1× so the lattice never scaled up. Now `.visualization-container` is capped to the viewport and `sticky` (so it stays in view while the controls scroll), and the fit scales up (≤4×) to fill the figure area. The lattice now renders large (~113%) and centered on load.
- **Dual-sim** — bumped the `contain` fit fill (0.85 → 0.92) so the lattices fill their boxes with less letterboxing.

## Testing
- [x] `tsc` clean; `eslint` no new errors; `jest` 296/296 pass; `build` OK
- [x] Verified in light + dark on Simulator and dual-simulation
- [ ] Preview deployment tested

## Related Issues
Fixes #50

## Checklist
- [x] Code follows project conventions
- [x] CI checks pass
