### PR TITLE
feat: maximize the lattice with a viewport-filling simulator layout (#52)

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -254,15 +254,11 @@
 }
 
 @media (max-width: 1200px) {
-  /* Stack the work columns; each panel and the canvas take full width. */
+  /* Stack the work columns; the canvas takes full width. Panel widths are
+     handled in CollapsiblePanel.css (after their base .left/.right rules, so
+     the full-width override wins the cascade). */
   .simulator-workspace {
     flex-direction: column;
-  }
-
-  .collapsible-panel.left,
-  .collapsible-panel.right {
-    width: 100%;
-    min-width: 0;
   }
 }
 

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -157,30 +157,50 @@
   border-bottom-color: var(--color-primary);
 }
 
-/* Main Content - Using CSS Grid for equal-height columns */
+/* Main Content - flex column: compact intro + presets sit at the top, the
+   workspace row fills the remaining height so the lattice can be maximized. */
 .main-content {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  grid-template-rows: 1fr;
-  align-items: stretch;
+  display: flex;
+  flex-direction: column;
   flex: 1;
   padding: 0.5rem;
   gap: 0.5rem;
   max-width: 1800px;
   margin: 0 auto;
   width: 100%;
+  box-sizing: border-box;
 }
 
-/* Ensure all collapsible panels stretch to full height */
+/* On desktop, pin the simulator to the viewport so the canvas reaches the
+   bottom and the side panels scroll internally instead of pushing the page
+   taller. Scoped to wide screens; narrow layouts (below) flow naturally.
+   --app-header-height is measured/declared on :root in global.css. */
+@media (min-width: 1201px) {
+  .main-content {
+    height: calc(100vh - var(--app-header-height, 66px));
+    overflow: hidden;
+  }
+}
+
+/* The three work columns: controls | lattice | info. Fills remaining height. */
+.simulator-workspace {
+  display: flex;
+  flex-direction: row;
+  gap: 0.5rem;
+  flex: 1 1 0;
+  min-height: 0;
+  width: 100%;
+}
+
+/* Ensure all collapsible panels stretch to full height of the workspace row. */
 .panel-section {
   height: 100%;
   align-self: stretch;
 }
 
-/* Dismissible in-UI notice banner (replaces blocking alert() dialogs).
-   Spans the full width of the simulator's 3-column grid. */
+/* Dismissible in-UI notice banner (replaces blocking alert() dialogs). */
 .simulator-alert {
-  grid-column: 1 / -1;
+  flex: 0 0 auto;
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
@@ -234,9 +254,15 @@
 }
 
 @media (max-width: 1200px) {
-  .main-content {
-    display: flex;
+  /* Stack the work columns; each panel and the canvas take full width. */
+  .simulator-workspace {
     flex-direction: column;
+  }
+
+  .collapsible-panel.left,
+  .collapsible-panel.right {
+    width: 100%;
+    min-width: 0;
   }
 }
 

--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -422,63 +422,68 @@ function MainSimulator() {
       )}
       <IntroPanel />
       <PresetBar onApplyPreset={handleApplyPreset} />
-      <CollapsiblePanel title="Controls" side="left" className="panel-section">
-        <ControlPanel
-          isRunning={isRunning}
-          latticeSize={latticeSize}
-          temperature={temperature}
-          seed={seed}
-          boundaryCondition={boundaryCondition}
-          dwbcType={dwbcType}
-          weights={weights}
-          renderMode={renderMode}
-          showGrid={showGrid}
-          animateFlips={animateFlips}
-          stepsPerFrame={stepsPerFrame}
-          onLatticeSizeChange={setLatticeSize}
-          onTemperatureChange={setTemperature}
-          onSeedChange={setSeed}
-          onBoundaryConditionChange={setBoundaryCondition}
-          onDwbcTypeChange={setDwbcType}
-          onWeightChange={handleWeightChange}
-          onRenderModeChange={setRenderMode}
-          onShowGridChange={setShowGrid}
-          onAnimateFlipsChange={setAnimateFlips}
-          onStepsPerFrameChange={setStepsPerFrame}
-          onStep={handleStep}
-          onRun={() => {
-            if (!simulationRef.current) {
-              console.error('Simulation not initialized');
-              initializeSimulation();
-              // Wait a bit for initialization then try to run
-              setTimeout(() => {
-                if (simulationRef.current) {
-                  setIsRunning(true);
-                } else {
-                  setErrorMessage('Failed to initialize simulation. Please try resetting.');
-                }
-              }, 100);
-            } else {
-              setIsRunning(true);
-            }
-          }}
-          onPause={handlePause}
-          onReset={handleReset}
-          onExportImage={handleExportImage}
+      <div className="simulator-workspace">
+        <CollapsiblePanel title="Controls" side="left" className="panel-section">
+          <ControlPanel
+            isRunning={isRunning}
+            latticeSize={latticeSize}
+            temperature={temperature}
+            seed={seed}
+            boundaryCondition={boundaryCondition}
+            dwbcType={dwbcType}
+            weights={weights}
+            renderMode={renderMode}
+            showGrid={showGrid}
+            animateFlips={animateFlips}
+            stepsPerFrame={stepsPerFrame}
+            onLatticeSizeChange={setLatticeSize}
+            onTemperatureChange={setTemperature}
+            onSeedChange={setSeed}
+            onBoundaryConditionChange={setBoundaryCondition}
+            onDwbcTypeChange={setDwbcType}
+            onWeightChange={handleWeightChange}
+            onRenderModeChange={setRenderMode}
+            onShowGridChange={setShowGrid}
+            onAnimateFlipsChange={setAnimateFlips}
+            onStepsPerFrameChange={setStepsPerFrame}
+            onStep={handleStep}
+            onRun={() => {
+              if (!simulationRef.current) {
+                console.error('Simulation not initialized');
+                initializeSimulation();
+                // Wait a bit for initialization then try to run
+                setTimeout(() => {
+                  if (simulationRef.current) {
+                    setIsRunning(true);
+                  } else {
+                    setErrorMessage('Failed to initialize simulation. Please try resetting.');
+                  }
+                }, 100);
+              } else {
+                setIsRunning(true);
+              }
+            }}
+            onPause={handlePause}
+            onReset={handleReset}
+            onExportImage={handleExportImage}
+          />
+        </CollapsiblePanel>
+
+        <VisualizationCanvas
+          renderer={rendererRef.current}
+          latticeState={latticeState}
+          onRendererReady={handleRendererReady}
+          renderConfig={renderConfig}
         />
-      </CollapsiblePanel>
 
-      <VisualizationCanvas
-        renderer={rendererRef.current}
-        latticeState={latticeState}
-        onRendererReady={handleRendererReady}
-        renderConfig={renderConfig}
-      />
-
-      <CollapsiblePanel title="Info" side="right" className="panel-section">
-        <StatisticsPanel stats={stats} fps={fps} />
-        <SaveLoadPanel getCurrentData={getCurrentSimulationData} onLoadData={loadSimulationData} />
-      </CollapsiblePanel>
+        <CollapsiblePanel title="Info" side="right" className="panel-section">
+          <StatisticsPanel stats={stats} fps={fps} />
+          <SaveLoadPanel
+            getCurrentData={getCurrentSimulationData}
+            onLoadData={loadSimulationData}
+          />
+        </CollapsiblePanel>
+      </div>
     </div>
   );
 }

--- a/client/src/components/CollapsiblePanel.css
+++ b/client/src/components/CollapsiblePanel.css
@@ -113,7 +113,10 @@
 .panel-content {
   flex: 1;
   width: 100%;
-  overflow: hidden;
+  /* Scroll the panel's own content when it is taller than the workspace row,
+     instead of growing the whole page. */
+  overflow-y: auto;
+  overflow-x: hidden;
   background: transparent;
   border-radius: 0;
   box-shadow: none;

--- a/client/src/components/CollapsiblePanel.css
+++ b/client/src/components/CollapsiblePanel.css
@@ -152,6 +152,16 @@
     max-width: none;
   }
 
+  /* The base .left/.right rules pin width to 300px at (0,2,0) specificity; this
+     same-specificity override is declared later in this file, so it wins and the
+     stacked panels fill the column width on tablet/mobile. */
+  .collapsible-panel.left,
+  .collapsible-panel.right {
+    width: 100%;
+    min-width: 0;
+    max-width: none;
+  }
+
   .collapsible-panel.collapsed {
     width: 100%;
     height: 48px;

--- a/client/src/components/IntroPanel.css
+++ b/client/src/components/IntroPanel.css
@@ -1,27 +1,81 @@
 .intro-panel {
-  position: relative;
-  grid-column: 1 / -1;
+  flex: 0 0 auto;
+  width: 100%;
   background: var(--surface-raised);
   border: 1px solid var(--color-info-border);
   border-radius: var(--border-radius-lg);
-  box-shadow: var(--shadow-md);
-  padding: var(--spacing-lg) var(--spacing-xl);
-  max-width: 70ch;
-  margin: 0 auto;
-  width: 100%;
+  box-shadow: var(--shadow-sm);
+  padding: var(--spacing-xs) var(--spacing-md);
+  box-sizing: border-box;
   animation: introFadeIn 0.3s ease-out;
 }
 
-.intro-panel__heading {
-  margin: 0 0 var(--spacing-sm);
-  font-size: var(--font-size-2xl);
+/* Compact single-row banner */
+.intro-panel__bar {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.intro-panel__lede {
+  margin: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
+}
+
+.intro-panel__title {
+  font-weight: 600;
   color: var(--color-primary);
-  padding-right: var(--spacing-xl);
+}
+
+.intro-panel__tagline {
+  color: var(--color-text-secondary);
+}
+
+.intro-panel__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-2xs);
+  flex: 0 0 auto;
+}
+
+.intro-panel__more {
+  background: transparent;
+  border: 1px solid var(--color-info-border);
+  color: var(--color-info-text);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  white-space: nowrap;
+  padding: var(--spacing-2xs) var(--spacing-sm);
+  border-radius: var(--border-radius-full);
+  cursor: pointer;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.intro-panel__more:hover {
+  background: var(--color-info-light);
+  border-color: var(--color-primary);
+}
+
+.intro-panel__more:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.intro-panel__detail {
+  max-width: 80ch;
+  padding-top: var(--spacing-sm);
+  margin-top: var(--spacing-xs);
+  border-top: 1px solid var(--color-border);
 }
 
 .intro-panel__body {
-  margin: 0 0 var(--spacing-md);
-  font-size: var(--font-size-base);
+  margin: 0 0 var(--spacing-sm);
+  font-size: var(--font-size-sm);
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
 }
@@ -34,15 +88,12 @@
 }
 
 .intro-panel__dismiss {
-  position: absolute;
-  top: var(--spacing-sm);
-  right: var(--spacing-sm);
   background: transparent;
   border: none;
   color: var(--color-text-secondary);
-  font-size: var(--font-size-2xl);
+  font-size: var(--font-size-xl);
   line-height: 1;
-  padding: var(--spacing-2xs) var(--spacing-xs);
+  padding: 0 var(--spacing-2xs);
   cursor: pointer;
   border-radius: var(--border-radius-sm);
   opacity: 0.7;
@@ -60,9 +111,9 @@
 
 /* Compact reopen affordance shown once the intro is dismissed. */
 .intro-reopen {
-  grid-column: 1 / -1;
+  flex: 0 0 auto;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   width: 100%;
 }
 

--- a/client/src/components/IntroPanel.tsx
+++ b/client/src/components/IntroPanel.tsx
@@ -13,6 +13,7 @@ function readDismissed(): boolean {
 
 function IntroPanel() {
   const [dismissed, setDismissed] = useState<boolean>(readDismissed);
+  const [expanded, setExpanded] = useState<boolean>(false);
 
   // Persist dismissal so the intro stays closed across reloads.
   useEffect(() => {
@@ -29,6 +30,7 @@ function IntroPanel() {
 
   const handleDismiss = useCallback(() => setDismissed(true), []);
   const handleReopen = useCallback(() => setDismissed(false), []);
+  const handleToggle = useCallback(() => setExpanded((prev) => !prev), []);
 
   if (dismissed) {
     return (
@@ -47,26 +49,47 @@ function IntroPanel() {
 
   return (
     <section className="intro-panel" aria-labelledby="intro-panel-heading">
-      <button
-        type="button"
-        className="intro-panel__dismiss"
-        onClick={handleDismiss}
-        aria-label="Dismiss the introduction"
-      >
-        &times;
-      </button>
-      <h2 id="intro-panel-heading" className="intro-panel__heading">
-        You&rsquo;re looking at square ice.
-      </h2>
-      <p className="intro-panel__body">
-        Picture water molecules frozen on a grid where every junction obeys one rule &mdash; the ice
-        rule: exactly two bonds point in and two point out. There are only six ways a junction can
-        do this: the six vertex types. Each picture is one valid arrangement out of an astronomical
-        number, and the simulator nudges it at random, one local move (a &lsquo;flip&rsquo;) at a
-        time. With the default domain-wall boundary, the corners freeze into rigid order while a
-        circular central region stays liquid-like and random &mdash; the famous Arctic circle.
-      </p>
-      <p className="intro-panel__hint">New here? Try a preset below to see it.</p>
+      <div className="intro-panel__bar">
+        <p className="intro-panel__lede" id="intro-panel-heading">
+          <span className="intro-panel__title">You&rsquo;re looking at square ice.</span>{' '}
+          <span className="intro-panel__tagline">
+            Every junction obeys the ice rule &mdash; two bonds in, two out.
+          </span>
+        </p>
+        <div className="intro-panel__actions">
+          <button
+            type="button"
+            className="intro-panel__more"
+            onClick={handleToggle}
+            aria-expanded={expanded}
+            aria-controls="intro-panel-detail"
+          >
+            {expanded ? 'Less' : 'Learn more'}
+          </button>
+          <button
+            type="button"
+            className="intro-panel__dismiss"
+            onClick={handleDismiss}
+            aria-label="Dismiss the introduction"
+          >
+            &times;
+          </button>
+        </div>
+      </div>
+      {expanded && (
+        <div id="intro-panel-detail" className="intro-panel__detail">
+          <p className="intro-panel__body">
+            Picture water molecules frozen on a grid where every junction obeys one rule &mdash; the
+            ice rule: exactly two bonds point in and two point out. There are only six ways a
+            junction can do this: the six vertex types. Each picture is one valid arrangement out of
+            an astronomical number, and the simulator nudges it at random, one local move (a
+            &lsquo;flip&rsquo;) at a time. With the default domain-wall boundary, the corners freeze
+            into rigid order while a circular central region stays liquid-like and random &mdash;
+            the famous Arctic circle.
+          </p>
+          <p className="intro-panel__hint">New here? Try a preset below to see it.</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/client/src/components/PresetBar.css
+++ b/client/src/components/PresetBar.css
@@ -1,18 +1,22 @@
 .preset-bar {
-  grid-column: 1 / -1;
+  flex: 0 0 auto;
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: var(--spacing-sm) var(--spacing-md);
   padding: var(--spacing-sm) var(--spacing-md);
   background: var(--surface-sunken);
+  border: 1px solid var(--color-border);
   border-radius: var(--border-radius-lg);
   width: 100%;
+  box-sizing: border-box;
 }
 
 .preset-bar__lead {
-  font-size: var(--font-size-sm);
+  font-size: var(--font-size-xs);
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
   color: var(--color-text-secondary);
   flex: 0 0 auto;
 }

--- a/client/src/components/VisualizationCanvas.css
+++ b/client/src/components/VisualizationCanvas.css
@@ -1,5 +1,9 @@
 .visualization-container {
-  flex: 1;
+  /* The lattice is the focus: fill all remaining width and height of the
+     workspace row so the figure is maximized. min-* lets it shrink in flex. */
+  flex: 1 1 0;
+  min-width: 0;
+  min-height: 0;
   background: var(--color-bg-primary);
   border-radius: 12px;
   box-shadow: var(--shadow-md);
@@ -8,30 +12,33 @@
   display: flex;
   flex-direction: column;
   transition: all var(--transition-base);
-  /* The side control/stats panels are tall; without this the grid stretches the
-     canvas column to match them and the centered lattice falls below the fold.
-     Cap to the viewport and stick so the figure stays visible while the controls
-     scroll. align-self:start opts out of the grid's stretch. */
-  align-self: start;
-  position: sticky;
-  top: 0.5rem;
-  max-height: calc(100vh - 5.5rem);
-  min-height: 420px;
+}
+
+/* On narrow/stacked layouts there is no fixed workspace height, so give the
+   figure a generous concrete height instead of collapsing to its content. */
+@media (max-width: 1200px) {
+  .visualization-container {
+    min-height: min(70vh, 560px);
+  }
 }
 
 .canvas-wrapper {
   flex: 1;
   position: relative;
   overflow: hidden;
+  /* Flex-center the figure so it stays centered at any zoom. (The old
+     top/left:50% + translate(-50%) + scale combination drifted off-center as
+     zoom changed.) Pan/zoom are applied on .canvas-transform around its own
+     center, so pan:0 keeps the lattice perfectly centered. */
+  display: flex;
+  align-items: center;
+  justify-content: center;
   /* Flat background so the scientific figure reads cleanly (no checkerboard). */
   background-color: var(--color-bg-secondary);
   transition: background var(--transition-base);
 }
 
 .canvas-transform {
-  position: absolute;
-  top: 50%;
-  left: 50%;
   transform-origin: center center;
   transition: transform 0.1s ease-out;
 }
@@ -41,7 +48,6 @@
   background: transparent;
   border-radius: 4px;
   box-shadow: 0 2px 8px var(--color-shadow);
-  transform: translate(-50%, -50%);
 }
 
 .canvas-controls {

--- a/client/src/components/VisualizationCanvas.tsx
+++ b/client/src/components/VisualizationCanvas.tsx
@@ -21,6 +21,10 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
+  // Mirror of isDragging for the ResizeObserver, so it can skip re-fitting
+  // mid-drag without the effect re-subscribing (a re-subscribe fires an initial
+  // ResizeObserver callback, which would snap the user's pan back to fit).
+  const isDraggingRef = useRef(false);
   const [dragStart, setDragStart] = useState({ x: 0, y: 0 });
   const [hoveredVertex, setHoveredVertex] = useState<{ row: number; col: number } | null>(null);
 
@@ -59,6 +63,7 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
       if (e.button === 0) {
         // Left click
         setIsDragging(true);
+        isDraggingRef.current = true;
         setDragStart({ x: e.clientX - pan.x, y: e.clientY - pan.y });
       }
     },
@@ -94,10 +99,12 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
 
   const handleMouseUp = useCallback(() => {
     setIsDragging(false);
+    isDraggingRef.current = false;
   }, []);
 
   const handleMouseLeave = useCallback(() => {
     setIsDragging(false);
+    isDraggingRef.current = false;
     setHoveredVertex(null);
   }, []);
 
@@ -146,6 +153,25 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
     const id = requestAnimationFrame(() => handleFitToScreen());
     return () => cancelAnimationFrame(id);
   }, [latticeSize, handleFitToScreen]);
+
+  // Keep the lattice maximized when the available space changes (collapsing a
+  // side panel, expanding the intro, window resize). Re-fit on container resize,
+  // skipping while the user is actively panning so we don't fight the drag.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') return;
+    let frame = 0;
+    const observer = new ResizeObserver(() => {
+      if (isDraggingRef.current) return;
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => handleFitToScreen());
+    });
+    observer.observe(container);
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [handleFitToScreen]);
 
   return (
     <div className="visualization-container" ref={containerRef}>

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -133,6 +133,10 @@
   --vertex-b2: #56b4e9;
   --vertex-c1: #009e73;
   --vertex-c2: #cc79a7;
+
+  /* Approximate height of the sticky app header; used to pin the simulator
+     workspace to the remaining viewport height (see App.css .main-content). */
+  --app-header-height: 70px;
 }
 
 /* Dark Theme */


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-53.dev.6v.allison.la

## Summary
Adversarial overhaul of the main simulator layout so the **lattice is the dominant, maximized focus** instead of a tiny slice in an oversized column. The work area now fills the viewport and the figure reaches the bottom of the screen.

## Changes
- **Viewport-filling layout:** `.main-content` is now a flex column pinned to the viewport on desktop (`calc(100vh - header)`); a new `.simulator-workspace` flex row (controls | lattice | info) fills the remaining height. Side panels scroll internally instead of growing the page.
- **Maximized, centered lattice:** replaced the canvas centering (`top/left:50%` + `translate(-50%)` + `scale`, which drifted off-center as zoom changed) with robust flex centering. A `ResizeObserver` re-fits the lattice when available space changes (collapsing a panel, expanding the intro, window resize), skipping mid-drag via a ref so it never snaps the user's pan back.
- **Compact intro:** `IntroPanel` is now a slim single-row banner with a `Learn more` disclosure instead of a full-screen card.
- **Contained presets:** `PresetBar` gets a visible bordered container with an integrated label.
- **Responsive fix:** stacked side panels now correctly fill the column width on tablet/mobile (cascade-order bug fixed).

## Testing
- [x] `tsc --noEmit` clean
- [x] `eslint` — 0 errors
- [x] `npm run build` passes
- [x] `jest` — 296/296 tests pass (23 suites)
- [x] Visual verification via chrome-devtools at 1440px (light + dark), 1000px (tablet), 760px (mobile stacked)
- [x] Lattice confirmed perfectly centered (offset 0,0) and maximized

## Related Issues
Fixes #52

## Checklist
- [x] Code follows project conventions
- [x] No regressions identified (light/dark/responsive)
- [x] CI checks pass
- [x] Preview link included
