### PR TITLE
feat: scale to large lattices (1024×1024+) via raw typed-array state + bitmap renderer (#55)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -2,12 +2,13 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import type {
   SimulationController,
   LatticeState,
+  RawLatticeState,
   SimulationParams,
   SimulationStats,
   RenderConfig,
 } from './lib/six-vertex/types';
 import { RenderMode, BoundaryCondition } from './lib/six-vertex/types';
-import { createSimulation } from './lib/six-vertex/simulation';
+import { createSimulation, LARGE_LATTICE_THRESHOLD } from './lib/six-vertex/simulation';
 import type { SimulationConfig } from './lib/six-vertex/simulation';
 import { PathRenderer } from './lib/six-vertex/renderer/pathRenderer';
 import ControlPanel from './components/ControlPanel';
@@ -37,9 +38,37 @@ function MainSimulator() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [stats, setStats] = useState<SimulationStats | null>(null);
   const [latticeState, setLatticeState] = useState<LatticeState | null>(null);
+  // Compact typed-array state used for large lattices (avoids ~N*N object churn).
+  const [rawState, setRawState] = useState<RawLatticeState | null>(null);
   const [latticeSize, setLatticeSize] = useState(10);
   const [fps, setFps] = useState(0);
   const [stepsPerFrame, setStepsPerFrame] = useState(10);
+
+  // Large lattices render from the raw typed array rather than the object form.
+  const isLarge = latticeSize > LARGE_LATTICE_THRESHOLD;
+  const isLargeRef = useRef(isLarge);
+  isLargeRef.current = isLarge;
+
+  // Pull the latest compact snapshot from the engine into React state so the
+  // canvas redraws via the fast bitmap path. Used for large lattices instead of
+  // the per-step onStateChange object payload.
+  const pullRawState = useCallback(() => {
+    const raw = simulationRef.current?.getRawState();
+    if (raw) {
+      setRawState(raw);
+    }
+  }, []);
+
+  // Refs mirror the latest state so callbacks (notably onRendererReady) can read
+  // them without changing identity every frame. Without this, a renderer-ready
+  // callback that closed over rawState/latticeState would be recreated each
+  // frame during a run, re-running the renderer-creation effect and allocating a
+  // fresh PathRenderer (and large canvas context) per frame — which crashes the
+  // tab for big lattices.
+  const latticeStateRef = useRef<LatticeState | null>(null);
+  latticeStateRef.current = latticeState;
+  const rawStateRef = useRef<RawLatticeState | null>(null);
+  rawStateRef.current = rawState;
 
   // Simulation parameters
   const [temperature, setTemperature] = useState(1.0);
@@ -113,20 +142,37 @@ function MainSimulator() {
       simulation.initialize(latticeSize, latticeSize, params);
 
       if (simulation) {
-        const state = simulation.getState();
-        setLatticeState(state);
+        const large = latticeSize > LARGE_LATTICE_THRESHOLD;
         setStats(simulation.getStats());
-
-        if (rendererRef.current) {
-          rendererRef.current.render(state);
+        if (large) {
+          // Large lattices render from the compact typed array; never build the
+          // ~N*N object form or draw per-cell paths.
+          setLatticeState(null);
+          const raw = simulation.getRawState();
+          if (raw) {
+            setRawState(raw);
+            rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+          }
+        } else {
+          setRawState(null);
+          const state = simulation.getState();
+          setLatticeState(state);
+          rendererRef.current?.render(state);
         }
       }
 
       // Set up event handlers
       simulation.on('onStateChange', (state: LatticeState) => {
-        setLatticeState(state);
-        if (rendererRef.current) {
-          rendererRef.current.render(state);
+        if (isLargeRef.current) {
+          // Ignore the object payload; pull the compact snapshot instead.
+          const raw = simulationRef.current?.getRawState();
+          if (raw) {
+            setRawState(raw);
+            rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+          }
+        } else {
+          setLatticeState(state);
+          rendererRef.current?.render(state);
         }
       });
 
@@ -155,16 +201,17 @@ function MainSimulator() {
     };
   }, [latticeSize, boundaryCondition, dwbcType, seed, initializeSimulation]); // Re-initialize on these changes
 
-  // Handle renderer ready
-  const handleRendererReady = useCallback(
-    (renderer: PathRenderer) => {
-      rendererRef.current = renderer;
-      if (latticeState) {
-        renderer.render(latticeState);
-      }
-    },
-    [latticeState],
-  );
+  // Handle renderer ready. Stable identity (empty deps + refs) so the
+  // renderer-creation effect in VisualizationCanvas does not re-run every frame.
+  const handleRendererReady = useCallback((renderer: PathRenderer) => {
+    rendererRef.current = renderer;
+    const raw = rawStateRef.current;
+    if (raw) {
+      renderer.renderRaw(raw.width, raw.height, raw.vertices);
+    } else if (latticeStateRef.current) {
+      renderer.render(latticeStateRef.current);
+    }
+  }, []);
 
   // Update weight
   const handleWeightChange = useCallback(
@@ -191,6 +238,10 @@ function MainSimulator() {
     try {
       if (simulationRef.current) {
         simulationRef.current.step();
+        // Large lattices don't emit an object onStateChange; pull raw to redraw.
+        if (isLargeRef.current) {
+          pullRawState();
+        }
       } else {
         console.error('Simulation not initialized');
         // Don't call initializeSimulation here to avoid circular dependency
@@ -199,7 +250,7 @@ function MainSimulator() {
       console.error('Error during step:', error);
       setErrorMessage(`Error during step: ${error}`);
     }
-  }, []);
+  }, [pullRawState]);
 
   const runSimulation = useCallback(() => {
     if (!simulationRef.current || !isRunning) return;
@@ -210,6 +261,12 @@ function MainSimulator() {
         if (simulationRef.current) {
           simulationRef.current.step();
         }
+      }
+
+      // Large lattices skip the per-step object onStateChange; pull the compact
+      // snapshot once per frame to redraw via the fast bitmap path.
+      if (isLargeRef.current) {
+        pullRawState();
       }
 
       animationFrameRef.current = requestAnimationFrame(() => runSimulation());
@@ -223,7 +280,7 @@ function MainSimulator() {
       // Don't show alert in animation loop to avoid spam
       console.error('Simulation stopped due to error:', error);
     }
-  }, [isRunning, stepsPerFrame]);
+  }, [isRunning, stepsPerFrame, pullRawState]);
 
   const handlePause = useCallback(() => {
     setIsRunning(false);
@@ -251,8 +308,8 @@ function MainSimulator() {
     (config: PresetConfig) => {
       handlePause();
 
-      // Clamp lattice size to the bounds the ControlPanel slider enforces (4–100).
-      const clampedSize = Math.min(100, Math.max(4, Math.round(config.latticeSize)));
+      // Clamp lattice size to the bounds the ControlPanel enforces (4–1024).
+      const clampedSize = Math.min(1024, Math.max(4, Math.round(config.latticeSize)));
 
       setBoundaryCondition(config.boundaryCondition);
       setDwbcType(config.dwbcType);
@@ -471,7 +528,8 @@ function MainSimulator() {
 
         <VisualizationCanvas
           renderer={rendererRef.current}
-          latticeState={latticeState}
+          latticeState={isLarge ? null : latticeState}
+          rawState={isLarge ? rawState : null}
           onRendererReady={handleRendererReady}
           renderConfig={renderConfig}
         />

--- a/client/src/components/ControlPanel.css
+++ b/client/src/components/ControlPanel.css
@@ -223,6 +223,27 @@
   color: var(--color-text-primary);
 }
 
+/* Exact numeric entry beside the size slider (supports values past the slider max). */
+.value-input {
+  width: 4.5rem;
+  text-align: center;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius-md);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+/* Small contextual note under a control (e.g. large-lattice mode hint). */
+.control-note {
+  display: block;
+  margin-top: var(--spacing-xs);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
 /* Inline label row with an info affordance */
 .control-label-row {
   display: inline-flex;
@@ -243,7 +264,10 @@
 
 .info-hint:focus-visible {
   outline: none;
-  box-shadow: var(--focus-ring, 0 0 0 3px color-mix(in srgb, var(--color-primary) 35%, transparent));
+  box-shadow: var(
+    --focus-ring,
+    0 0 0 3px color-mix(in srgb, var(--color-primary) 35%, transparent)
+  );
 }
 
 /* Teaching legend: the six vertex types */

--- a/client/src/components/ControlPanel.tsx
+++ b/client/src/components/ControlPanel.tsx
@@ -235,19 +235,36 @@ const ControlPanel: React.FC<ControlPanelProps> = ({
             <div className="slider-with-value">
               <input
                 type="range"
-                value={latticeSize}
+                value={Math.min(latticeSize, 256)}
                 onChange={(e) => onLatticeSizeChange(parseInt(e.target.value))}
                 min={4}
-                max={100}
+                max={256}
                 step={1}
                 className="slider"
                 aria-label="Lattice size (N by N)"
                 aria-valuetext={`${latticeSize} by ${latticeSize}`}
               />
-              <output className="value-display" aria-live="polite">
-                {latticeSize}
-              </output>
+              <input
+                type="number"
+                value={latticeSize}
+                onChange={(e) => {
+                  const n = parseInt(e.target.value);
+                  if (!Number.isNaN(n)) {
+                    onLatticeSizeChange(Math.min(1024, Math.max(4, n)));
+                  }
+                }}
+                min={4}
+                max={1024}
+                step={1}
+                className="value-input"
+                aria-label="Lattice size exact value (4 to 1024)"
+              />
             </div>
+            {latticeSize > 128 && (
+              <span className="control-note">
+                Large lattice — fast bitmap view (vertices coloured by type).
+              </span>
+            )}
           </label>
         </div>
 

--- a/client/src/components/VisualizationCanvas.tsx
+++ b/client/src/components/VisualizationCanvas.tsx
@@ -1,11 +1,16 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
-import type { LatticeState, RenderConfig } from '../lib/six-vertex/types';
+import type { LatticeState, RawLatticeState, RenderConfig } from '../lib/six-vertex/types';
 import { PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
 import './VisualizationCanvas.css';
 
 interface VisualizationCanvasProps {
   renderer: PathRenderer | null;
   latticeState: LatticeState | null;
+  /**
+   * Compact typed-array state for large lattices. When present it takes
+   * precedence over latticeState and is drawn via the fast bitmap path.
+   */
+  rawState?: RawLatticeState | null;
   onRendererReady: (renderer: PathRenderer) => void;
   renderConfig: Partial<RenderConfig>;
 }
@@ -13,6 +18,7 @@ interface VisualizationCanvasProps {
 const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
   renderer,
   latticeState,
+  rawState,
   onRendererReady,
   renderConfig,
 }) => {
@@ -40,21 +46,24 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
     };
   }, [renderConfig.cellSize, onRendererReady]); // Re-create renderer when cell size changes
 
-  // Update renderer config
+  // Update renderer config + draw. Large lattices use the fast raw bitmap path
+  // and take precedence over the object-based render.
   useEffect(() => {
     if (renderer) {
       renderer.updateConfig(renderConfig);
-      if (latticeState) {
+      if (rawState) {
+        renderer.renderRaw(rawState.width, rawState.height, rawState.vertices);
+      } else if (latticeState) {
         renderer.render(latticeState);
       }
     }
-  }, [renderer, renderConfig, latticeState]);
+  }, [renderer, renderConfig, latticeState, rawState]);
 
   // Handle zoom
   const handleWheel = useCallback((e: WheelEvent) => {
     e.preventDefault();
     const delta = e.deltaY > 0 ? 0.9 : 1.1;
-    setZoom((prevZoom) => Math.min(Math.max(prevZoom * delta, 0.25), 4));
+    setZoom((prevZoom) => Math.min(Math.max(prevZoom * delta, 0.1), 8));
   }, []);
 
   // Handle pan
@@ -114,25 +123,38 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
     setPan({ x: 0, y: 0 });
   }, []);
 
+  // Canvas content dimensions in device pixels. Raw (bitmap) lattices size the
+  // canvas to the lattice itself (one pixel per vertex); object lattices use
+  // (N+1)*cellSize. These are PRIMITIVES and stay constant during a run (only the
+  // pixel data changes), so handleFitToScreen below keeps a stable identity and
+  // the auto-fit/ResizeObserver effects don't re-fire every frame.
+  const cellSize = renderConfig.cellSize || 30;
+  const contentWidth = rawState
+    ? rawState.width
+    : latticeState
+      ? (latticeState.width + 1) * cellSize
+      : 0;
+  const contentHeight = rawState
+    ? rawState.height
+    : latticeState
+      ? (latticeState.height + 1) * cellSize
+      : 0;
+
   // Fit to screen
   const handleFitToScreen = useCallback(() => {
-    if (!containerRef.current || !canvasRef.current || !latticeState) return;
+    if (!containerRef.current || !contentWidth || !contentHeight) return;
 
     const containerRect = containerRef.current.getBoundingClientRect();
-    const cellSize = renderConfig.cellSize || 30;
-    const canvasWidth = (latticeState.width + 1) * cellSize;
-    const canvasHeight = (latticeState.height + 1) * cellSize;
-
     // Fit to the container with a small margin, scaling UP for small lattices so
     // they fill the figure area instead of sitting tiny (capped to keep large
     // lattices crisp).
-    const scaleX = (containerRect.width - 48) / canvasWidth;
-    const scaleY = (containerRect.height - 48) / canvasHeight;
-    const newZoom = Math.min(Math.max(Math.min(scaleX, scaleY), 0.25), 4);
+    const scaleX = (containerRect.width - 48) / contentWidth;
+    const scaleY = (containerRect.height - 48) / contentHeight;
+    const newZoom = Math.min(Math.max(Math.min(scaleX, scaleY), 0.1), 8);
 
     setZoom(newZoom);
     setPan({ x: 0, y: 0 });
-  }, [latticeState, renderConfig.cellSize]);
+  }, [contentWidth, contentHeight]);
 
   // Add wheel event listener
   useEffect(() => {
@@ -145,7 +167,11 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
 
   // Auto-fit the lattice on initial mount and whenever the lattice size (N) changes,
   // so it never sits tiny in a large canvas. The manual "Fit to Screen" button remains.
-  const latticeSize = latticeState ? `${latticeState.width}x${latticeState.height}` : null;
+  const latticeSize = rawState
+    ? `raw:${rawState.width}x${rawState.height}`
+    : latticeState
+      ? `${latticeState.width}x${latticeState.height}`
+      : null;
   useEffect(() => {
     if (!latticeSize) return;
     // Defer to the next frame so the container has its measured size and the
@@ -209,7 +235,7 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
       <div className="canvas-controls">
         <button
           className="zoom-button"
-          onClick={() => setZoom((z) => Math.min(z * 1.2, 4))}
+          onClick={() => setZoom((z) => Math.min(z * 1.2, 8))}
           title="Zoom In"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">
@@ -224,7 +250,7 @@ const VisualizationCanvas: React.FC<VisualizationCanvasProps> = ({
 
         <button
           className="zoom-button"
-          onClick={() => setZoom((z) => Math.max(z * 0.8, 0.25))}
+          onClick={() => setZoom((z) => Math.max(z * 0.8, 0.1))}
           title="Zoom Out"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor">

--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -618,6 +618,13 @@ export class OptimizedPhysicsSimulation {
   }
 
   /**
+   * Linear dimension N of the (square) lattice.
+   */
+  public getSize(): number {
+    return this.size;
+  }
+
+  /**
    * Get current state as a standard LatticeState (for rendering)
    */
   public getState(): any {

--- a/client/src/lib/six-vertex/renderer/latticeBitmap.ts
+++ b/client/src/lib/six-vertex/renderer/latticeBitmap.ts
@@ -1,0 +1,53 @@
+/**
+ * Fast bitmap rendering for large lattices.
+ *
+ * For very large N (e.g. 1024x1024) drawing every vertex as bold path segments
+ * is infeasible. Instead we paint one pixel per vertex, coloured by vertex type,
+ * straight into an ImageData buffer and blit it with a single putImageData. The
+ * canvas is sized to the lattice (one device pixel per vertex); the surrounding
+ * pan/zoom transform scales it up, so draw cost is bounded by vertex count, not
+ * by on-screen pixels or zoom level.
+ *
+ * The numeric vertex ids match the VERTEX_* constants in cStyleFlipLogic
+ * (a1=0, a2=1, b1=2, b2=3, c1=4, c2=5).
+ */
+
+// Okabe–Ito CVD-safe palette, matching the --vertex-* tokens in global.css.
+// Order is [a1, a2, b1, b2, c1, c2].
+const VERTEX_RGB: ReadonlyArray<readonly [number, number, number]> = [
+  [0xd5, 0x5e, 0x00], // a1
+  [0xe6, 0x9f, 0x00], // a2
+  [0x00, 0x72, 0xb2], // b1
+  [0x56, 0xb4, 0xe9], // b2
+  [0x00, 0x9e, 0x73], // c1
+  [0xcc, 0x79, 0xa7], // c2
+];
+
+/**
+ * Paint a flat row-major Int8Array of numeric vertex types into the context,
+ * one pixel per vertex. `vertices` must have at least width*height entries.
+ */
+export function paintLatticeBitmap(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  vertices: Int8Array,
+): void {
+  const count = width * height;
+  const img = ctx.createImageData(width, height);
+  const data = img.data;
+  for (let i = 0; i < count; i++) {
+    const rgb = VERTEX_RGB[vertices[i]] ?? VERTEX_RGB[0];
+    const o = i << 2;
+    data[o] = rgb[0];
+    data[o + 1] = rgb[1];
+    data[o + 2] = rgb[2];
+    data[o + 3] = 0xff;
+  }
+  ctx.putImageData(img, 0, 0);
+}
+
+/** The RGB triple a numeric vertex type maps to (exposed for tests). */
+export function vertexTypeRgb(type: number): readonly [number, number, number] {
+  return VERTEX_RGB[type] ?? VERTEX_RGB[0];
+}

--- a/client/src/lib/six-vertex/renderer/pathRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/pathRenderer.ts
@@ -8,6 +8,7 @@ import { RenderMode, EdgeState, VertexType } from '../types';
 import { getPathSegments } from '../vertexShapes';
 import type { PathSegment } from '../vertexShapes';
 import { renderContinuousPaths } from './continuousPathRenderer';
+import { paintLatticeBitmap } from './latticeBitmap';
 
 /**
  * Main renderer class for the 6-vertex model
@@ -62,6 +63,22 @@ export class PathRenderer {
    */
   updateConfig(config: Partial<RenderConfig>): void {
     this.config = { ...this.config, ...config };
+  }
+
+  /**
+   * Fast path for large lattices: paint one pixel per vertex (coloured by type)
+   * from a flat typed array, sizing the canvas to the lattice. The enclosing
+   * pan/zoom transform scales the bitmap up, so cost is bounded by vertex count
+   * rather than on-screen pixels. Bypasses the per-cell path/grid drawing that
+   * is infeasible at e.g. 1024x1024.
+   */
+  renderRaw(width: number, height: number, vertices: Int8Array): void {
+    if (this.canvas.width !== width || this.canvas.height !== height) {
+      this.canvas.width = width;
+      this.canvas.height = height;
+    }
+    this.ctx.imageSmoothingEnabled = false;
+    paintLatticeBitmap(this.ctx, width, height, vertices);
   }
 
   /**

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -333,7 +333,9 @@ export class MonteCarloSimulation implements SimulationController {
    * Perform a single Monte Carlo step
    */
   step(): void {
-    if (!this.state) {
+    // Large lattices keep this.state null (object form is built lazily), so guard
+    // on the optimized engine too — otherwise stepping silently no-ops for big N.
+    if (!this.state && !this.optimizedSim) {
       console.error('Simulation not initialized - cannot step');
       return; // Don't throw, just return silently
     }
@@ -369,14 +371,18 @@ export class MonteCarloSimulation implements SimulationController {
       return; // Stats and state updates handled by callbacks
     }
 
-    // Original implementation
+    // Original (non-optimized) implementation. Only reached when no optimized
+    // engine/worker is present, in which case this.state is always populated.
+    if (!this.state) return;
+    const state = this.state;
+
     // Choose a random position
-    const row = this.rng.randomInt(0, this.state.height);
-    const col = this.rng.randomInt(0, this.state.width);
+    const row = this.rng.randomInt(0, state.height);
+    const col = this.rng.randomInt(0, state.width);
     const position: Position = { row, col };
 
     // Find valid flips at this position
-    const flips = findValidFlips(this.state, position);
+    const flips = findValidFlips(state, position);
 
     if (flips.length === 0) {
       this.stats.flipAttempts++;
@@ -387,7 +393,7 @@ export class MonteCarloSimulation implements SimulationController {
     const flip = this.rng.choice(flips);
 
     // Calculate energy change
-    const deltaE = calculateFlipEnergyChange(this.state, flip, this.params.weights);
+    const deltaE = calculateFlipEnergyChange(state, flip, this.params.weights);
 
     // Metropolis acceptance criterion
     const acceptProbability = Math.min(1, Math.exp(-this.params.beta * deltaE));
@@ -396,9 +402,7 @@ export class MonteCarloSimulation implements SimulationController {
 
     if (this.rng.random() < acceptProbability) {
       // Accept the flip
-      if (this.state) {
-        this.state = executeFlip(this.state, flip);
-      }
+      this.state = executeFlip(state, flip);
       this.stats.successfulFlips++;
       this.emit('onFlip', flip);
       this.emit('onStateChange', this.state);
@@ -413,7 +417,7 @@ export class MonteCarloSimulation implements SimulationController {
    * Run simulation for a specified number of steps
    */
   async run(steps: number): Promise<void> {
-    if (!this.state) {
+    if (!this.state && !this.optimizedSim) {
       throw new Error('Simulation not initialized');
     }
 
@@ -422,7 +426,8 @@ export class MonteCarloSimulation implements SimulationController {
 
     // Use optimized batch processing if available
     if (this.optimizedSim) {
-      const batchSize = this.state.width <= 24 ? 1000 : this.state.width <= 50 ? 500 : 100;
+      const n = this.optimizedSim.getSize();
+      const batchSize = n <= 24 ? 1000 : n <= 50 ? 500 : 100;
       let remaining = steps;
 
       while (remaining > 0 && this.isRunningFlag && !this.isPaused) {

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -8,6 +8,7 @@
 
 import type {
   LatticeState,
+  RawLatticeState,
   SimulationParams,
   SimulationStats,
   SimulationController,
@@ -35,10 +36,23 @@ export interface SimulationConfig {
 }
 
 /**
+ * Above this linear size (N), the facade stops rebuilding the object LatticeState
+ * (~N*N Vertex objects) on every step and instead exposes a compact typed-array
+ * snapshot via getRawState(). Callers render large lattices from the raw buffer;
+ * the object form is rebuilt lazily only if getState() is actually called.
+ */
+export const LARGE_LATTICE_THRESHOLD = 128;
+
+/**
  * Main simulation engine implementation with automatic optimization
  */
 export class MonteCarloSimulation implements SimulationController {
   private state: LatticeState | null = null;
+  // For large lattices the object state is rebuilt lazily; this marks it stale.
+  private stateDirty = false;
+  // Lattice dimensions, tracked separately so reset() works even when the object
+  // state is null (large lattices defer building it).
+  private dims: { width: number; height: number } | null = null;
   private params: SimulationParams;
   private rng: SeededRNG;
   private stats: SimulationStats;
@@ -123,6 +137,7 @@ export class MonteCarloSimulation implements SimulationController {
   initialize(width: number, height: number, params: SimulationParams): void {
     this.params = params;
     this.rng.setSeed(params.seed || Date.now());
+    this.dims = { width, height };
 
     // Determine which implementation to use based on size
     const size = Math.min(width, height);
@@ -146,7 +161,7 @@ export class MonteCarloSimulation implements SimulationController {
         batchSize: size <= 24 ? 100 : size <= 50 ? 50 : 20,
         initialState: params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
       });
-      this.state = this.optimizedSim.getState();
+      this.adoptOptimizedState();
     }
     // Initialize worker if needed
     else if (this.useWorker) {
@@ -222,7 +237,7 @@ export class MonteCarloSimulation implements SimulationController {
       batchSize: size <= 24 ? 100 : size <= 50 ? 50 : 20,
       initialState: params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
     });
-    this.state = this.optimizedSim.getState();
+    this.adoptOptimizedState();
   }
 
   private generateInitialState(width: number, height: number, params: SimulationParams): void {
@@ -235,6 +250,12 @@ export class MonteCarloSimulation implements SimulationController {
   }
 
   private updateStats(): void {
+    // Large lattices: emit stats only (no object payload); callers pull raw state.
+    if (this.isLargeLattice() && this.optimizedSim) {
+      this.stats = this.optimizedSim.getStats();
+      this.emit('onStep', this.stats);
+      return;
+    }
     if (this.state) {
       this.updateStatistics();
       this.emit('onStateChange', this.state);
@@ -245,9 +266,9 @@ export class MonteCarloSimulation implements SimulationController {
    * Reset the simulation
    */
   reset(): void {
-    if (!this.state) return;
+    if (!this.dims) return;
 
-    const { width, height } = this.state;
+    const { width, height } = this.dims;
     this.initialize(width, height, this.params);
   }
 
@@ -255,10 +276,48 @@ export class MonteCarloSimulation implements SimulationController {
    * Get current lattice state
    */
   getState(): LatticeState {
+    // For large lattices the object form is only rebuilt on demand (e.g. for
+    // save/export), not on every step. Rebuild it here if it has gone stale.
+    if (this.stateDirty && this.optimizedSim) {
+      this.state = this.optimizedSim.getState();
+      this.stateDirty = false;
+    }
     if (!this.state) {
       throw new Error('Simulation not initialized');
     }
     return this.state;
+  }
+
+  /**
+   * Whether this controller is running a large lattice on the optimized engine,
+   * in which case callers should render from getRawState() rather than getState().
+   */
+  private isLargeLattice(): boolean {
+    return !!this.optimizedSim && this.optimizedSim.getSize() > LARGE_LATTICE_THRESHOLD;
+  }
+
+  getRawState(): RawLatticeState | null {
+    if (!this.optimizedSim) {
+      return null;
+    }
+    const size = this.optimizedSim.getSize();
+    return { width: size, height: size, vertices: this.optimizedSim.getRawState() };
+  }
+
+  /**
+   * After (re)initializing the optimized engine, adopt its state. Large lattices
+   * defer the ~N*N object build (rendered from getRawState() instead); smaller
+   * ones build the object form eagerly as before.
+   */
+  private adoptOptimizedState(): void {
+    if (!this.optimizedSim) return;
+    if (this.optimizedSim.getSize() > LARGE_LATTICE_THRESHOLD) {
+      this.state = null;
+      this.stateDirty = true;
+    } else {
+      this.state = this.optimizedSim.getState();
+      this.stateDirty = false;
+    }
   }
 
   /**
@@ -283,10 +342,16 @@ export class MonteCarloSimulation implements SimulationController {
       // Use optimized implementation if available
       if (this.optimizedSim) {
         this.optimizedSim.run(1);
-        this.state = this.optimizedSim.getState();
         this.stats = this.optimizedSim.getStats();
-        if (this.state) {
-          this.emit('onStateChange', this.state);
+        if (this.isLargeLattice()) {
+          // Skip the ~N*N object rebuild and heavy onStateChange payload; callers
+          // render from getRawState(). The object form is rebuilt lazily if needed.
+          this.stateDirty = true;
+        } else {
+          this.state = this.optimizedSim.getState();
+          if (this.state) {
+            this.emit('onStateChange', this.state);
+          }
         }
         this.emit('onStep', this.stats);
         return;
@@ -363,10 +428,14 @@ export class MonteCarloSimulation implements SimulationController {
       while (remaining > 0 && this.isRunningFlag && !this.isPaused) {
         const batch = Math.min(batchSize, remaining);
         this.optimizedSim.run(batch);
-        this.state = this.optimizedSim.getState();
         this.stats = this.optimizedSim.getStats();
-        if (this.state) {
-          this.emit('onStateChange', this.state);
+        if (this.isLargeLattice()) {
+          this.stateDirty = true;
+        } else {
+          this.state = this.optimizedSim.getState();
+          if (this.state) {
+            this.emit('onStateChange', this.state);
+          }
         }
         this.emit('onStep', this.stats);
 

--- a/client/src/lib/six-vertex/types.ts
+++ b/client/src/lib/six-vertex/types.ts
@@ -94,6 +94,18 @@ export interface LatticeState {
 }
 
 /**
+ * Compact lattice state for large lattices: numeric vertex-type ids in a flat,
+ * row-major typed array (index = row * width + col). Avoids allocating ~width*height
+ * objects per frame, which is the bottleneck for very large N (e.g. 1024x1024).
+ * The numeric ids match the VERTEX_* constants in cStyleFlipLogic (a1=0..c2=5).
+ */
+export interface RawLatticeState {
+  width: number;
+  height: number;
+  vertices: Int8Array;
+}
+
+/**
  * Boundary conditions for the lattice
  */
 export const BoundaryCondition = {
@@ -209,6 +221,11 @@ export interface SimulationController {
   initialize(width: number, height: number, params: SimulationParams): void;
   reset(): void;
   getState(): LatticeState;
+  /**
+   * Compact typed-array snapshot for large lattices, or null when no optimized
+   * engine backs this controller (small lattices use getState() instead).
+   */
+  getRawState(): RawLatticeState | null;
   setState(state: LatticeState): void;
 
   // Simulation control

--- a/client/tests/six-vertex/rawState.test.ts
+++ b/client/tests/six-vertex/rawState.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from '@jest/globals';
+// Test the engine directly (OptimizedPhysicsSimulation) rather than the
+// MonteCarloSimulation facade: the facade transitively imports the Web Worker
+// module, whose import.meta.url is incompatible with the ts-jest module target.
+import { OptimizedPhysicsSimulation } from '../../src/lib/six-vertex/optimizedSimulation';
+import { paintLatticeBitmap, vertexTypeRgb } from '../../src/lib/six-vertex/renderer/latticeBitmap';
+
+// Numeric vertex ids -> VertexType string, matching cStyleFlipLogic (a1=0..c2=5).
+const NUM_TO_TYPE = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'];
+const WEIGHTS = { a1: 1, a2: 1, b1: 1, b2: 1, c1: 1, c2: 1 };
+
+describe('getRawState (typed-array snapshot)', () => {
+  it('returns a flat row-major Int8Array whose ids match getState() vertex types', () => {
+    const sim = new OptimizedPhysicsSimulation({ size: 16, weights: WEIGHTS, seed: 12345 });
+
+    const raw = sim.getRawState();
+    expect(raw.length).toBe(16 * 16);
+    expect(sim.getSize()).toBe(16);
+
+    const state = sim.getState();
+    for (let row = 0; row < state.height; row++) {
+      for (let col = 0; col < state.width; col++) {
+        const id = raw[row * state.width + col];
+        expect(NUM_TO_TYPE[id]).toBe(state.vertices[row][col].type);
+      }
+    }
+  });
+
+  it('all ids are valid vertex types (0..5) and DWBC-high anti-diagonal is c2', () => {
+    const N = 24;
+    const sim = new OptimizedPhysicsSimulation({
+      size: N,
+      weights: WEIGHTS,
+      seed: 1,
+      initialState: 'dwbc-high',
+    });
+    const raw = sim.getRawState();
+    for (let i = 0; i < raw.length; i++) {
+      expect(raw[i]).toBeGreaterThanOrEqual(0);
+      expect(raw[i]).toBeLessThanOrEqual(5);
+    }
+    // DWBC-high places c2 (id 5) on the anti-diagonal (row + col === N - 1).
+    for (let r = 0; r < N; r++) {
+      const c = N - 1 - r;
+      expect(NUM_TO_TYPE[raw[r * N + c]]).toBe('c2');
+    }
+  });
+
+  it('handles large lattices (1024) and stays consistent after stepping', () => {
+    const N = 1024;
+    const sim = new OptimizedPhysicsSimulation({ size: N, weights: WEIGHTS, seed: 7 });
+    const raw = sim.getRawState();
+    expect(raw.length).toBe(N * N);
+    sim.run(500);
+    const raw2 = sim.getRawState();
+    expect(raw2.length).toBe(N * N);
+    for (let i = 0; i < raw2.length; i += 4096) {
+      expect(raw2[i]).toBeGreaterThanOrEqual(0);
+      expect(raw2[i]).toBeLessThanOrEqual(5);
+    }
+  });
+});
+
+describe('latticeBitmap', () => {
+  it('maps each numeric vertex type to a distinct RGB', () => {
+    const seen = new Set<string>();
+    for (let t = 0; t < 6; t++) {
+      const [r, g, b] = vertexTypeRgb(t);
+      seen.add(`${r},${g},${b}`);
+    }
+    expect(seen.size).toBe(6);
+  });
+
+  it('paints one pixel per vertex with the type colour', () => {
+    let painted: ImageData | null = null;
+    const ctx = {
+      createImageData: (w: number, h: number) => ({
+        width: w,
+        height: h,
+        data: new Uint8ClampedArray(w * h * 4),
+        colorSpace: 'srgb' as PredefinedColorSpace,
+      }),
+      putImageData: (img: ImageData) => {
+        painted = img;
+      },
+    } as unknown as CanvasRenderingContext2D;
+
+    const vertices = Int8Array.from([0, 1, 2, 3]); // 2x2
+    paintLatticeBitmap(ctx, 2, 2, vertices);
+
+    expect(painted).not.toBeNull();
+    const data = painted!.data;
+    for (let i = 0; i < 4; i++) {
+      const [r, g, b] = vertexTypeRgb(vertices[i]);
+      expect([data[i * 4], data[i * 4 + 1], data[i * 4 + 2], data[i * 4 + 3]]).toEqual([
+        r,
+        g,
+        b,
+        255,
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-61.dev.6v.allison.la

## Summary
First foundation PR of EPIC #54. Enables much larger lattices (designed for **1024×1024+**) by rendering from a compact typed-array snapshot instead of rebuilding ~N×N `Vertex` objects every step and drawing every cell.

## Changes
- **Raw state:** `RawLatticeState` + `SimulationController.getRawState()` (flat row-major `Int8Array`). Engine already stored `Int8Array` internally.
- **Facade:** above `LARGE_LATTICE_THRESHOLD` (128) the per-step object rebuild + `onStateChange` payload are skipped (lazy `getState()`); init/reset never build the object form (dims tracked separately so `reset()` still works).
- **Bitmap renderer:** `latticeBitmap.paintLatticeBitmap` paints one pixel per vertex (Okabe–Ito palette) into an `ImageData`; `PathRenderer.renderRaw()` blits it and the pan/zoom transform scales it — draw cost bounded by vertex count, not zoom.
- **VisualizationCanvas:** `rawState` prop → bitmap path; fit logic now keyed on stable content **dimensions** (primitives) so auto-fit/ResizeObserver don't re-fire each frame.
- **MainSimulator:** large lattices render from `getRawState()`; `onRendererReady` made stable (refs) so the renderer isn't recreated per frame.
- **ControlPanel:** size slider to 256 + exact number input to 1024, with a large-lattice hint.

## Testing
- [x] `tsc` clean, `eslint` 0 errors, `npm run build` passes
- [x] `jest` 301/301 (incl. new rawState/bitmap tests + a 1024² engine run)
- [x] Static 256² render verified visually (correct DWBC-high b1/b2 triangles + c2 anti-diagonal) before the browser tool crashed
- [ ] ⚠️ **Live verification of a *running* large lattice is pending** — the browser automation tool crashed mid-session (which surfaced and led to fixing two per-frame allocation/setState storms). Needs a manual Run check on the preview at 256 and 1024 before merge.

## Related Issues
Fixes #55 · Part of EPIC #54

## Checklist
- [x] Physics unchanged for small lattices (existing suite green)
- [x] CI checks pass
- [ ] Running-large-lattice verified in-browser (preview) — **blocking merge**
