### PR TITLE
feat: import/export lattice configurations (#57)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -365,6 +365,8 @@ function MainSimulator() {
           handlePause();
         }
 
+        const large = data.latticeState.width > LARGE_LATTICE_THRESHOLD;
+
         // Import the data into the simulation
         if (simulationRef.current) {
           simulationRef.current.importData({
@@ -374,8 +376,7 @@ function MainSimulator() {
           });
 
           // Update local state to match loaded data
-          setLatticeState(data.latticeState);
-          setStats(data.stats);
+          setStats(simulationRef.current.getStats());
           setLatticeSize(data.latticeState.width);
           setTemperature(data.params.temperature);
           setWeights(data.params.weights);
@@ -387,9 +388,20 @@ function MainSimulator() {
             setSeed(data.params.seed);
           }
 
-          // Re-render the loaded state
-          if (rendererRef.current && data.latticeState) {
-            rendererRef.current.render(data.latticeState);
+          // Re-render the loaded state. Large lattices use the compact bitmap
+          // path (pulled from the engine, which importData now actually loads);
+          // building the per-cell object form for ~1M cells would freeze the tab.
+          if (large) {
+            setLatticeState(null);
+            const raw = simulationRef.current.getRawState();
+            if (raw) {
+              setRawState(raw);
+              rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+            }
+          } else {
+            setRawState(null);
+            setLatticeState(data.latticeState);
+            rendererRef.current?.render(data.latticeState);
           }
         } else {
           // If no simulation exists, create one with the loaded params
@@ -411,8 +423,7 @@ function MainSimulator() {
           });
 
           // Update local state
-          setLatticeState(data.latticeState);
-          setStats(data.stats);
+          setStats(simulation.getStats());
           setLatticeSize(data.latticeState.width);
           setTemperature(data.params.temperature);
           setWeights(data.params.weights);
@@ -424,15 +435,35 @@ function MainSimulator() {
             setSeed(data.params.seed);
           }
 
-          // Set up event handlers
+          // Render the freshly imported state (large via bitmap, else objects).
+          if (large) {
+            setLatticeState(null);
+            const raw = simulation.getRawState();
+            if (raw) {
+              setRawState(raw);
+              rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+            }
+          } else {
+            setRawState(null);
+            setLatticeState(data.latticeState);
+            rendererRef.current?.render(data.latticeState);
+          }
+
+          // Set up event handlers (large-aware, mirroring initializeSimulation).
           simulation.on('onStep', (newStats) => {
             setStats(newStats);
           });
 
           simulation.on('onStateChange', (newState) => {
-            setLatticeState(newState);
-            if (rendererRef.current) {
-              rendererRef.current.render(newState);
+            if (isLargeRef.current) {
+              const raw = simulationRef.current?.getRawState();
+              if (raw) {
+                setRawState(raw);
+                rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+              }
+            } else {
+              setLatticeState(newState);
+              rendererRef.current?.render(newState);
             }
           });
         }

--- a/client/src/components/SaveLoadPanel.css
+++ b/client/src/components/SaveLoadPanel.css
@@ -284,6 +284,26 @@
   font-size: 13px;
 }
 
+/* Import / Export */
+.save-load-panel__hint {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--color-text-secondary, #555);
+}
+
+.save-load-panel__io-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.save-load-panel__io-actions .save-load-panel__button {
+  flex: 1 1 auto;
+  padding: 6px 12px;
+  font-size: 13px;
+}
+
 /* Scrollbar styling */
 .save-load-panel__saves::-webkit-scrollbar {
   width: 6px;

--- a/client/src/components/SaveLoadPanel.tsx
+++ b/client/src/components/SaveLoadPanel.tsx
@@ -2,7 +2,7 @@
  * UI component for saving and loading simulations
  */
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   storageService,
   type SavedSimulation,
@@ -10,6 +10,12 @@ import {
   type SaveResult,
   type LoadResult,
 } from '../lib/storage';
+import {
+  serializeToJson,
+  simulationToCsv,
+  deserializeSimulation,
+  SixVParseError,
+} from '../lib/six-vertex/serialization';
 import './SaveLoadPanel.css';
 
 interface SaveLoadPanelProps {
@@ -198,6 +204,72 @@ export const SaveLoadPanel: React.FC<SaveLoadPanelProps> = ({
     }).format(date);
   };
 
+  // --- Import / Export (portable files, clipboard, CSV) ---
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const triggerDownload = useCallback((contents: string, filename: string, mime: string) => {
+    const blob = new Blob([contents], { type: mime });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const handleExportFile = useCallback(() => {
+    const data = getCurrentData();
+    if (!data) {
+      setError('No simulation to export');
+      return;
+    }
+    const n = data.latticeState.width;
+    triggerDownload(serializeToJson(data), `6vertex-${n}x${n}.6v.json`, 'application/json');
+    setSuccess('Exported configuration file');
+  }, [getCurrentData, triggerDownload]);
+
+  const handleCopyJson = useCallback(async () => {
+    const data = getCurrentData();
+    if (!data) {
+      setError('No simulation to copy');
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(serializeToJson(data));
+      setSuccess('Configuration copied to clipboard');
+    } catch {
+      setError('Clipboard not available; use Export file instead');
+    }
+  }, [getCurrentData]);
+
+  const handleExportCsv = useCallback(() => {
+    const data = getCurrentData();
+    if (!data) {
+      setError('No simulation to export');
+      return;
+    }
+    const n = data.latticeState.width;
+    triggerDownload(simulationToCsv(data), `6vertex-${n}x${n}.csv`, 'text/csv');
+    setSuccess('Exported vertex grid as CSV');
+  }, [getCurrentData, triggerDownload]);
+
+  const handleImportFile = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      event.target.value = ''; // allow re-importing the same file
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const data = deserializeSimulation(text);
+        onLoadData(data);
+        setSuccess(`Imported ${data.latticeState.width}×${data.latticeState.height} lattice`);
+      } catch (err) {
+        setError(err instanceof SixVParseError ? err.message : 'Failed to import file');
+      }
+    },
+    [onLoadData],
+  );
+
   return (
     <div className="save-load-section">
       <div className="save-load-panel">
@@ -272,6 +344,52 @@ export const SaveLoadPanel: React.FC<SaveLoadPanelProps> = ({
             >
               {isLoading ? 'Saving...' : 'Save'}
             </button>
+          </div>
+        </div>
+
+        {/* Import / Export Section */}
+        <div className="save-load-panel__section">
+          <h4>Import / Export</h4>
+          <p className="save-load-panel__hint">
+            Portable <code>.6v.json</code> files (any lattice size), or a CSV of the vertex grid.
+          </p>
+          <div className="save-load-panel__io-actions">
+            <button
+              onClick={handleExportFile}
+              className="save-load-panel__button"
+              title="Download a .6v.json file of the current lattice and parameters"
+            >
+              Export file
+            </button>
+            <button
+              onClick={handleCopyJson}
+              className="save-load-panel__button"
+              title="Copy the configuration JSON to the clipboard"
+            >
+              Copy JSON
+            </button>
+            <button
+              onClick={handleExportCsv}
+              className="save-load-panel__button"
+              title="Download the vertex-type grid as CSV"
+            >
+              Export CSV
+            </button>
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              className="save-load-panel__button save-load-panel__button--primary"
+              title="Load a .6v.json file"
+            >
+              Import file
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json,.6v.json,application/json"
+              onChange={handleImportFile}
+              style={{ display: 'none' }}
+              aria-hidden="true"
+            />
           </div>
         </div>
 

--- a/client/src/lib/six-vertex/serialization.ts
+++ b/client/src/lib/six-vertex/serialization.ts
@@ -1,0 +1,147 @@
+/**
+ * Versioned import/export format for 6-vertex lattice configurations.
+ *
+ * The lattice is stored compactly as base64 of a byte-per-vertex numeric type
+ * array (a1=0 … c2=5), so a 1024×1024 lattice serializes to ~1.4 MB of text
+ * instead of millions of JSON objects. Round-trips exactly.
+ */
+
+import type { SimulationData } from '../storage';
+import type { LatticeState, SimulationParams, VertexType, Vertex } from './types';
+import { getVertexConfiguration } from './types';
+
+export const SIXV_FORMAT = '6v-lattice';
+export const SIXV_VERSION = 1;
+
+// Numeric vertex ids ↔ VertexType, matching cStyleFlipLogic (a1=0 … c2=5).
+const NUM_TO_TYPE: VertexType[] = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'] as VertexType[];
+const TYPE_TO_NUM: Record<string, number> = { a1: 0, a2: 1, b1: 2, b2: 3, c1: 4, c2: 5 };
+
+export interface SixVFile {
+  format: typeof SIXV_FORMAT;
+  version: number;
+  width: number;
+  height: number;
+  params: SimulationParams;
+  /** base64 of a Uint8Array, row-major, one numeric vertex type per cell. */
+  vertices: string;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const chunk = 0x8000; // avoid call-stack overflow on large arrays
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
+
+function base64ToBytes(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+/** Flatten a LatticeState's vertex types into a row-major byte array. */
+function latticeToBytes(state: LatticeState): Uint8Array {
+  const { width, height, vertices } = state;
+  const bytes = new Uint8Array(width * height);
+  for (let r = 0; r < height; r++) {
+    for (let c = 0; c < width; c++) {
+      bytes[r * width + c] = TYPE_TO_NUM[vertices[r][c].type] ?? 0;
+    }
+  }
+  return bytes;
+}
+
+/** Rebuild a LatticeState (object form) from a row-major byte array. */
+function bytesToLattice(bytes: Uint8Array, width: number, height: number): LatticeState {
+  const vertices: Vertex[][] = [];
+  for (let r = 0; r < height; r++) {
+    const row: Vertex[] = [];
+    for (let c = 0; c < width; c++) {
+      const type = NUM_TO_TYPE[bytes[r * width + c]] ?? NUM_TO_TYPE[0];
+      row.push({ position: { row: r, col: c }, type, configuration: getVertexConfiguration(type) });
+    }
+    vertices.push(row);
+  }
+  return { width, height, vertices, horizontalEdges: [], verticalEdges: [] };
+}
+
+/** Serialize the current simulation to the portable, versioned file object. */
+export function serializeSimulation(data: SimulationData): SixVFile {
+  const { latticeState, params } = data;
+  return {
+    format: SIXV_FORMAT,
+    version: SIXV_VERSION,
+    width: latticeState.width,
+    height: latticeState.height,
+    params,
+    vertices: bytesToBase64(latticeToBytes(latticeState)),
+  };
+}
+
+/** Pretty-printed JSON string for download / clipboard. */
+export function serializeToJson(data: SimulationData): string {
+  return JSON.stringify(serializeSimulation(data), null, 2);
+}
+
+export class SixVParseError extends Error {}
+
+/** Parse + validate a file object back into SimulationData. Throws SixVParseError. */
+export function deserializeSimulation(input: unknown): SimulationData {
+  let obj: unknown = input;
+  if (typeof input === 'string') {
+    try {
+      obj = JSON.parse(input);
+    } catch {
+      throw new SixVParseError('File is not valid JSON.');
+    }
+  }
+  const file = obj as Partial<SixVFile>;
+  if (!file || file.format !== SIXV_FORMAT) {
+    throw new SixVParseError('Not a 6-vertex lattice file.');
+  }
+  if (file.version !== SIXV_VERSION) {
+    throw new SixVParseError(
+      `Unsupported file version ${String(file.version)} (this build reads version ${SIXV_VERSION}).`,
+    );
+  }
+  if (
+    typeof file.width !== 'number' ||
+    typeof file.height !== 'number' ||
+    typeof file.vertices !== 'string' ||
+    !file.params
+  ) {
+    throw new SixVParseError('File is missing required fields.');
+  }
+  const bytes = base64ToBytes(file.vertices);
+  if (bytes.length !== file.width * file.height) {
+    throw new SixVParseError('Vertex data length does not match width × height.');
+  }
+  const latticeState = bytesToLattice(bytes, file.width, file.height);
+  return {
+    latticeState,
+    params: file.params,
+    stats: {
+      step: 0,
+      energy: 0,
+      vertexCounts: { a1: 0, a2: 0, b1: 0, b2: 0, c1: 0, c2: 0 },
+      acceptanceRate: 0,
+      flipAttempts: 0,
+      successfulFlips: 0,
+      beta: file.params.beta,
+    },
+  };
+}
+
+/** Export the vertex-type grid as CSV (N rows of comma-separated type names). */
+export function simulationToCsv(data: SimulationData): string {
+  const { latticeState } = data;
+  const lines: string[] = [];
+  for (let r = 0; r < latticeState.height; r++) {
+    lines.push(latticeState.vertices[r].map((v) => v.type).join(','));
+  }
+  return lines.join('\n');
+}

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -679,10 +679,13 @@ export class MonteCarloSimulation implements SimulationController {
 
     // Reinitialize optimized simulation if needed
     const size = Math.min(data.state.width, data.state.height);
+    this.dims = { width: data.state.width, height: data.state.height };
     this.useOptimized = (this.config.useOptimized ?? true) && size > 8;
 
     if (this.useOptimized && !this.useWorker) {
-      // Recreate optimized simulation with the imported state
+      // Recreate the optimized engine, then load the imported configuration into
+      // it (previously this was a no-op, so the engine kept a default DWBC state
+      // and stepping ignored the import).
       this.optimizedSim = new OptimizedPhysicsSimulation({
         size,
         weights: data.params.weights,
@@ -691,16 +694,22 @@ export class MonteCarloSimulation implements SimulationController {
         initialState: data.params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
       });
 
-      // Set the imported state in the optimized simulation
-      if (this.optimizedSim) {
-        // Note: The optimized simulation may need a setState method
-        // For now, we'll just use the imported state directly
-        this.state = data.state;
+      // Flatten the imported vertex types into the engine's typed-array state.
+      const typeToNum: Record<string, number> = { a1: 0, a2: 1, b1: 2, b2: 3, c1: 4, c2: 5 };
+      const raw = new Int8Array(size * size);
+      for (let r = 0; r < size; r++) {
+        for (let c = 0; c < size; c++) {
+          raw[r * size + c] = typeToNum[data.state.vertices[r][c].type] ?? 0;
+        }
       }
+      this.optimizedSim.setState(raw);
+      this.stats = this.optimizedSim.getStats();
     }
 
     // Emit state change event
-    this.emit('onStateChange', this.state);
+    if (this.state) {
+      this.emit('onStateChange', this.state);
+    }
     this.emit('onStep', this.stats);
   }
 }

--- a/client/tests/six-vertex/serialization.test.ts
+++ b/client/tests/six-vertex/serialization.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from '@jest/globals';
+// serialization.ts only imports types + getVertexConfiguration from ./types and a
+// type-only SimulationData from ../storage, so (unlike the facade) it is safe to
+// import directly under ts-jest. We build lattices via the engine.
+import { OptimizedPhysicsSimulation } from '../../src/lib/six-vertex/optimizedSimulation';
+import {
+  serializeSimulation,
+  serializeToJson,
+  deserializeSimulation,
+  simulationToCsv,
+  SixVParseError,
+  SIXV_FORMAT,
+  SIXV_VERSION,
+} from '../../src/lib/six-vertex/serialization';
+import type { SimulationData } from '../../src/lib/storage';
+import type { SimulationParams } from '../../src/lib/six-vertex/types';
+
+const WEIGHTS = { a1: 1, a2: 1, b1: 1, b2: 1, c1: 1, c2: 1 };
+
+function makeData(size: number, seed = 999, steps = 0): SimulationData {
+  const sim = new OptimizedPhysicsSimulation({ size, weights: WEIGHTS, seed });
+  for (let i = 0; i < steps; i++) sim.step();
+  const params: SimulationParams = {
+    temperature: 1,
+    beta: 1,
+    weights: WEIGHTS,
+    boundaryCondition: 'dwbc',
+    seed,
+  };
+  return {
+    latticeState: sim.getState(),
+    params,
+    stats: sim.getStats() as SimulationData['stats'],
+  };
+}
+
+describe('serialization round-trip', () => {
+  it('preserves dimensions, params, and every vertex type', () => {
+    const data = makeData(16, 7, 50);
+    const restored = deserializeSimulation(serializeSimulation(data));
+
+    expect(restored.latticeState.width).toBe(data.latticeState.width);
+    expect(restored.latticeState.height).toBe(data.latticeState.height);
+    expect(restored.params.seed).toBe(data.params.seed);
+    expect(restored.params.boundaryCondition).toBe(data.params.boundaryCondition);
+
+    for (let r = 0; r < data.latticeState.height; r++) {
+      for (let c = 0; c < data.latticeState.width; c++) {
+        expect(restored.latticeState.vertices[r][c].type).toBe(
+          data.latticeState.vertices[r][c].type,
+        );
+      }
+    }
+  });
+
+  it('round-trips through the pretty-printed JSON string form', () => {
+    const data = makeData(24, 3, 100);
+    const json = serializeToJson(data);
+    expect(typeof json).toBe('string');
+    const restored = deserializeSimulation(json);
+    expect(restored.latticeState.width).toBe(24);
+    expect(restored.latticeState.vertices[0][0].type).toBe(data.latticeState.vertices[0][0].type);
+  });
+
+  it('reconstructs each vertex with a matching configuration object', () => {
+    const data = makeData(8);
+    const restored = deserializeSimulation(serializeSimulation(data));
+    const v = restored.latticeState.vertices[0][0];
+    expect(v.configuration).toBeDefined();
+    expect(v.position).toEqual({ row: 0, col: 0 });
+  });
+});
+
+describe('serialization format guards', () => {
+  it('stamps the canonical format and version', () => {
+    const file = serializeSimulation(makeData(8));
+    expect(file.format).toBe(SIXV_FORMAT);
+    expect(file.version).toBe(SIXV_VERSION);
+  });
+
+  it('rejects non-6v files', () => {
+    expect(() => deserializeSimulation({ format: 'something-else' })).toThrow(SixVParseError);
+    expect(() => deserializeSimulation('not json at all {')).toThrow(SixVParseError);
+  });
+
+  it('rejects unsupported versions', () => {
+    const file = serializeSimulation(makeData(8));
+    expect(() => deserializeSimulation({ ...file, version: 999 })).toThrow(/version/i);
+  });
+
+  it('rejects missing required fields', () => {
+    const file = serializeSimulation(makeData(8));
+    const noWidth: Partial<typeof file> = { ...file };
+    delete noWidth.width;
+    expect(() => deserializeSimulation(noWidth)).toThrow(SixVParseError);
+  });
+
+  it('rejects vertex data whose length disagrees with width × height', () => {
+    const file = serializeSimulation(makeData(8));
+    expect(() => deserializeSimulation({ ...file, width: 9 })).toThrow(/length/i);
+  });
+});
+
+describe('CSV export', () => {
+  it('emits one row per lattice row with comma-separated type names', () => {
+    const data = makeData(8);
+    const csv = simulationToCsv(data);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(8);
+    for (const line of lines) {
+      const cells = line.split(',');
+      expect(cells).toHaveLength(8);
+      for (const cell of cells) expect(['a1', 'a2', 'b1', 'b2', 'c1', 'c2']).toContain(cell);
+    }
+  });
+});
+
+describe('large-lattice base64 chunking', () => {
+  it('round-trips a lattice large enough to exercise multi-chunk base64', () => {
+    // 256×256 = 65536 bytes > the 0x8000 chunk size, so this covers the chunked
+    // bytesToBase64 path that a naive String.fromCharCode(...all) would overflow.
+    const data = makeData(256, 42, 5);
+    const restored = deserializeSimulation(serializeSimulation(data));
+    expect(restored.latticeState.width).toBe(256);
+    expect(restored.latticeState.height).toBe(256);
+    // spot-check a scattered set of cells
+    for (const [r, c] of [
+      [0, 0],
+      [128, 200],
+      [255, 255],
+      [17, 240],
+    ]) {
+      expect(restored.latticeState.vertices[r][c].type).toBe(data.latticeState.vertices[r][c].type);
+    }
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-65.dev.6v.allison.la

## Summary
Adds a portable, versioned import/export system for 6-vertex lattice configurations: download/upload `.6v.json` files, copy the configuration JSON to the clipboard, and export the vertex grid as CSV — at any lattice size, including 1024×1024.

Part of the large-lattice / workbench EPIC (#54).

## Changes
- **`serialization.ts` (new)** — versioned `6v-lattice` v1 format. The lattice is stored as base64 of a byte-per-vertex numeric array (a1=0…c2=5), so a 1024² lattice is ~1.4 MB of text rather than millions of JSON objects, and round-trips exactly. Chunked base64 avoids call-stack overflow on large arrays. `deserializeSimulation` validates format/version/required-fields/length and throws `SixVParseError` on bad input.
- **`SaveLoadPanel`** — new *Import / Export* section: **Export file**, **Copy JSON**, **Export CSV**, **Import file** (hidden file input). CSV mirrors the vertex-type grid.
- **`simulation.ts` — `importData` fix (real bug):** it previously recreated the optimized engine with a *fresh DWBC* state and never loaded the imported configuration (the code literally said *"for now, we'll just use the imported state directly"*), so stepping after an import started from the wrong lattice. It now flattens the imported vertices into the engine via `setState` and refreshes stats.
- **`MainSimulator.loadSimulationData`** — large-aware: imports above the large-lattice threshold render via the compact bitmap path instead of building the ~N·N object form (which would freeze the tab for a 1M-cell lattice).

## Testing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (changed files)
- [x] 10 new unit tests pass: round-trip, JSON-string form, version/format/field/length guards, CSV shape, 256² multi-chunk base64 round-trip
- [x] `npm run build` passes
- [x] In-browser: 256² evolved lattice round-trips with **0 mismatches**; after `importData` the engine raw state matches the import exactly (4096/4096 cells) and steps forward from it
- [ ] Preview deployment tested

## Related Issues
Refs #57 (EPIC #54)

## Checklist
- [x] Code follows project conventions
- [x] Tests added
- [x] CI checks pass
- [x] Preview link included
