### PR TITLE
perf: run Monte Carlo in a Web Worker for large lattices (#56)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -132,9 +132,17 @@ function MainSimulator() {
       // Use optimized simulation for better performance
       const simConfig: SimulationConfig = {
         useOptimized: true,
-        useWorker: false, // Disable worker for now to avoid issues
+        // Offload the MC loop to a Web Worker for large lattices. The facade
+        // gates this internally to size > LARGE_LATTICE_THRESHOLD and falls back
+        // to the main thread when workers are unavailable, so small lattices and
+        // step-by-step debugging keep their synchronous behavior.
+        useWorker: true,
         workerThreshold: 50,
       };
+
+      // Dispose the controller we're about to replace so its Web Worker (if any)
+      // is terminated rather than leaked. Idempotent with the effect cleanup.
+      simulationRef.current?.dispose?.();
 
       const simulation = createSimulation(params, simConfig);
       simulationRef.current = simulation;
@@ -192,10 +200,14 @@ function MainSimulator() {
   useEffect(() => {
     initializeSimulation();
 
+    const previous = simulationRef.current;
     return () => {
-      if (simulationRef.current?.isRunning()) {
-        simulationRef.current.pause();
+      if (previous?.isRunning()) {
+        previous.pause();
       }
+      // Terminate the discarded controller's Web Worker so threads don't leak
+      // across re-inits (size/seed/boundary changes recreate the simulation).
+      previous?.dispose?.();
       if (animationFrameRef.current) {
         cancelAnimationFrame(animationFrameRef.current);
       }
@@ -257,17 +269,21 @@ function MainSimulator() {
     if (!simulationRef.current || !isRunning) return;
 
     try {
-      // Run multiple steps per frame for performance
+      // Large lattices run inside a Web Worker: hand off to the facade's run()
+      // (which starts the worker's continuous loop) ONCE — the worker then pushes
+      // stats + raw snapshots via onStep/onStateChange, which redraw the canvas.
+      // Do NOT also drive a main-thread step loop here (would diverge/double-run).
+      if (isLargeRef.current) {
+        void simulationRef.current.run(Number.MAX_SAFE_INTEGER);
+        return;
+      }
+
+      // Small lattices stay fully synchronous on the main thread: step N times
+      // per animation frame and redraw from the object state via onStateChange.
       for (let i = 0; i < stepsPerFrame; i++) {
         if (simulationRef.current) {
           simulationRef.current.step();
         }
-      }
-
-      // Large lattices skip the per-step object onStateChange; pull the compact
-      // snapshot once per frame to redraw via the fast bitmap path.
-      if (isLargeRef.current) {
-        pullRawState();
       }
 
       animationFrameRef.current = requestAnimationFrame(() => runSimulation());
@@ -281,7 +297,7 @@ function MainSimulator() {
       // Don't show alert in animation loop to avoid spam
       console.error('Simulation stopped due to error:', error);
     }
-  }, [isRunning, stepsPerFrame, pullRawState]);
+  }, [isRunning, stepsPerFrame]);
 
   const handlePause = useCallback(() => {
     setIsRunning(false);
@@ -408,7 +424,7 @@ function MainSimulator() {
           const params: SimulationParams = data.params;
           const simConfig: SimulationConfig = {
             useOptimized: true,
-            useWorker: false,
+            useWorker: true,
             workerThreshold: 50,
           };
 

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -14,8 +14,9 @@ import type {
   SimulationController,
   SimulationEvents,
   Position,
+  Vertex,
 } from './types';
-import { VertexType, BoundaryCondition } from './types';
+import { VertexType, BoundaryCondition, getVertexConfiguration } from './types';
 import { SeededRNG } from './rng';
 import { findValidFlips, executeFlip, calculateFlipEnergyChange } from './flips';
 import { generateDWBCState, generateRandomIceState } from './initialStates';
@@ -68,6 +69,16 @@ export class MonteCarloSimulation implements SimulationController {
   private workerSim: WorkerSimulation | null = null;
   private useOptimized = false;
   private useWorker = false;
+
+  // Worker async-cache model: the worker engine is the source of truth in worker
+  // mode, but the facade's getStats()/getRawState() are synchronous. We cache the
+  // latest snapshots pushed by the worker (via callbacks) and serve them from the
+  // cache. getState() returns null in worker mode (consumers use the raw path).
+  private workerActive = false;
+  private latestRawState: RawLatticeState | null = null;
+  // Set when run() is called before the (async) worker has finished initializing.
+  // The worker starts its continuous loop as soon as it becomes ready.
+  private pendingRun = false;
 
   constructor(params?: Partial<SimulationParams>, config?: SimulationConfig) {
     this.params = this.getDefaultParams(params);
@@ -142,8 +153,16 @@ export class MonteCarloSimulation implements SimulationController {
     // Determine which implementation to use based on size
     const size = Math.min(width, height);
     this.useOptimized = (this.config.useOptimized ?? true) && size > 8;
+    // Only offload to a Web Worker for LARGE lattices, and only when the caller
+    // opted in and workers are actually supported. Small lattices stay fully
+    // synchronous on the main thread so step-by-step debugging and the object
+    // renderer keep working. The MC loop blocks the UI thread only for big N,
+    // which is exactly the case the worker exists to fix.
     this.useWorker =
-      this.config.useWorker ?? (size >= (this.config.workerThreshold ?? 50) && isWorkerSupported());
+      (this.config.useWorker ?? false) && size > LARGE_LATTICE_THRESHOLD && isWorkerSupported();
+    this.workerActive = false;
+    this.workerSim = null;
+    this.latestRawState = null;
 
     // Initialize optimized simulation if needed
     if (this.useOptimized && !this.useWorker) {
@@ -168,6 +187,8 @@ export class MonteCarloSimulation implements SimulationController {
       try {
         createWorkerSimulation(
           {
+            // Same config the main-thread optimized engine would use, so the
+            // worker reproduces the identical trajectory for a given seed.
             size,
             weights: params.weights || {
               a1: 1.0,
@@ -178,25 +199,43 @@ export class MonteCarloSimulation implements SimulationController {
               c2: 1.0,
             },
             seed: params.seed,
-            batchSize: size <= 50 ? 100 : 50,
+            batchSize: size <= 24 ? 100 : size <= 50 ? 50 : 20,
             initialState: params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
           },
           {
             onStats: (stats) => {
-              this.stats = stats;
-              this.emit('onStep', stats);
+              this.stats = stats as SimulationStats;
+              this.emit('onStep', this.stats);
             },
-            onState: (state) => {
-              this.state = state;
-              this.emit('onStateChange', state);
+            // Worker pushes a compact typed-array snapshot; cache it and emit
+            // onStateChange so the large-aware UI handler pulls via getRawState().
+            onRawState: (vertices, width, height) => {
+              this.latestRawState = { width, height, vertices };
+              // The object payload is unused for large worker mode; emit an empty
+              // sentinel and let the handler read getRawState().
+              this.emit('onStateChange', this.state as unknown as LatticeState);
+            },
+            onError: (error) => {
+              this.emit('onError', new Error(error));
             },
           },
         )
           .then((workerSim) => {
-            this.workerSim = workerSim;
-            // Request initial state
-            if (this.workerSim) {
-              this.workerSim.getState();
+            if (workerSim) {
+              this.workerSim = workerSim;
+              this.workerActive = true;
+              // Request an initial snapshot + stats to seed the cache.
+              workerSim.getRawState();
+              workerSim.getStats();
+              // If the user pressed Run before the worker finished initializing,
+              // honour that intent now (unless they paused/stopped in between).
+              if (this.pendingRun && this.isRunningFlag && !this.isPaused) {
+                workerSim.startContinuous(60);
+              }
+              this.pendingRun = false;
+            } else {
+              // Worker unavailable (e.g. test/build env): fall back cleanly.
+              this.fallBackToOptimized(size, params);
             }
           })
           .catch((error) => {
@@ -204,14 +243,11 @@ export class MonteCarloSimulation implements SimulationController {
               'Failed to create worker, falling back to optimized implementation',
               error,
             );
-            this.useWorker = false;
-            this.useOptimized = true;
-            // Fall back to optimized implementation
-            this.initializeOptimized(size, params);
+            this.fallBackToOptimized(size, params);
           });
       } catch (error) {
         console.warn('Worker creation failed', error);
-        this.initializeOptimized(size, params);
+        this.fallBackToOptimized(size, params);
       }
     } else {
       // Generate initial state without optimization
@@ -222,7 +258,18 @@ export class MonteCarloSimulation implements SimulationController {
     this.updateStats();
   }
 
-  private initializeOptimized(size: number, params: SimulationParams): void {
+  /**
+   * Fall back to the main-thread optimized engine when the worker cannot be used
+   * (unsupported, init failed, or test/build env). Fully initializes the engine
+   * and seeds the UI with an initial state + stats so nothing renders blank.
+   */
+  private fallBackToOptimized(size: number, params: SimulationParams): void {
+    this.useWorker = false;
+    this.workerActive = false;
+    this.workerSim = null;
+    this.latestRawState = null;
+    this.useOptimized = true;
+
     this.optimizedSim = new OptimizedPhysicsSimulation({
       size,
       weights: params.weights || {
@@ -238,6 +285,17 @@ export class MonteCarloSimulation implements SimulationController {
       initialState: params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
     });
     this.adoptOptimizedState();
+
+    // Seed the UI: large lattices render from the raw snapshot, others from the
+    // object form. updateStats() emits onStep, and (for small N) onStateChange.
+    this.stats = this.optimizedSim.getStats();
+    if (this.isLargeLattice()) {
+      this.emit('onStep', this.stats);
+      this.emit('onStateChange', this.state as unknown as LatticeState);
+    } else if (this.state) {
+      this.emit('onStateChange', this.state);
+      this.emit('onStep', this.stats);
+    }
   }
 
   private generateInitialState(width: number, height: number, params: SimulationParams): void {
@@ -268,8 +326,32 @@ export class MonteCarloSimulation implements SimulationController {
   reset(): void {
     if (!this.dims) return;
 
+    // Tear down any existing worker so initialize() can spin up a fresh one with
+    // the same seed (which reproduces the trajectory) without leaking the old.
+    if (this.workerSim) {
+      this.workerSim.stop();
+      this.workerSim.terminate();
+      this.workerSim = null;
+      this.workerActive = false;
+    }
+
     const { width, height } = this.dims;
     this.initialize(width, height, this.params);
+  }
+
+  /**
+   * Release background resources. Terminates the Web Worker (if any) so it does
+   * not leak when this controller is discarded (e.g. on re-init for a new size).
+   */
+  dispose(): void {
+    this.isRunningFlag = false;
+    this.pendingRun = false;
+    if (this.workerSim) {
+      this.workerSim.stop();
+      this.workerSim.terminate();
+      this.workerSim = null;
+      this.workerActive = false;
+    }
   }
 
   /**
@@ -282,10 +364,52 @@ export class MonteCarloSimulation implements SimulationController {
       this.state = this.optimizedSim.getState();
       this.stateDirty = false;
     }
+    // Worker mode keeps no object state on the main thread; rebuild it lazily
+    // from the cached raw snapshot when something actually needs it (e.g. save).
+    if (!this.state && this.workerActive && this.latestRawState) {
+      return this.buildStateFromRaw(this.latestRawState);
+    }
     if (!this.state) {
       throw new Error('Simulation not initialized');
     }
     return this.state;
+  }
+
+  /**
+   * Build the object-graph LatticeState from a compact raw snapshot. Expensive
+   * for large N, so only used on demand (save/export in worker mode).
+   */
+  private buildStateFromRaw(raw: RawLatticeState): LatticeState {
+    const numToType = [
+      VertexType.a1,
+      VertexType.a2,
+      VertexType.b1,
+      VertexType.b2,
+      VertexType.c1,
+      VertexType.c2,
+    ];
+    const vertices: Vertex[][] = [];
+    for (let row = 0; row < raw.height; row++) {
+      const rowVertices: Vertex[] = [];
+      for (let col = 0; col < raw.width; col++) {
+        const type = numToType[raw.vertices[row * raw.width + col]];
+        // Use the canonical mapping (single source of truth) so arrow/edge
+        // rendering of a worker-rebuilt state matches every other code path.
+        rowVertices.push({
+          position: { row, col },
+          type,
+          configuration: getVertexConfiguration(type),
+        });
+      }
+      vertices.push(rowVertices);
+    }
+    return {
+      width: raw.width,
+      height: raw.height,
+      vertices,
+      horizontalEdges: [],
+      verticalEdges: [],
+    };
   }
 
   /**
@@ -297,6 +421,11 @@ export class MonteCarloSimulation implements SimulationController {
   }
 
   getRawState(): RawLatticeState | null {
+    // Worker mode: serve the latest snapshot pushed by the worker. May be null
+    // briefly until the first snapshot arrives after init.
+    if (this.workerActive) {
+      return this.latestRawState;
+    }
     if (!this.optimizedSim) {
       return null;
     }
@@ -333,6 +462,13 @@ export class MonteCarloSimulation implements SimulationController {
    * Perform a single Monte Carlo step
    */
   step(): void {
+    // Worker mode: fire-and-forget; stats + raw state arrive via callbacks which
+    // update the cache and emit onStep/onStateChange.
+    if (this.workerActive && this.workerSim) {
+      this.workerSim.step();
+      return;
+    }
+
     // Large lattices keep this.state null (object form is built lazily), so guard
     // on the optimized engine too — otherwise stepping silently no-ops for big N.
     if (!this.state && !this.optimizedSim) {
@@ -363,12 +499,6 @@ export class MonteCarloSimulation implements SimulationController {
       // Try to recover or fallback
       this.emit('onError', error as Error);
       return;
-    }
-
-    // Use worker if available
-    if (this.workerSim) {
-      this.workerSim.run(1);
-      return; // Stats and state updates handled by callbacks
     }
 
     // Original (non-optimized) implementation. Only reached when no optimized
@@ -417,6 +547,26 @@ export class MonteCarloSimulation implements SimulationController {
    * Run simulation for a specified number of steps
    */
   async run(steps: number): Promise<void> {
+    // Worker mode: hand off to the worker's continuous loop. The worker pushes
+    // stats + raw snapshots via callbacks; stop()/pause() halts it. The promise
+    // resolves immediately because the loop lives in the worker thread.
+    if (this.workerActive && this.workerSim) {
+      this.isRunningFlag = true;
+      this.isPaused = false;
+      this.workerSim.startContinuous(60);
+      return;
+    }
+
+    // Worker intended but still initializing (async): record the intent so the
+    // worker starts as soon as it is ready, rather than throwing below (the
+    // optimized engine is intentionally not created in worker mode).
+    if (this.useWorker && !this.workerActive) {
+      this.isRunningFlag = true;
+      this.isPaused = false;
+      this.pendingRun = true;
+      return;
+    }
+
     if (!this.state && !this.optimizedSim) {
       throw new Error('Simulation not initialized');
     }
@@ -436,6 +586,10 @@ export class MonteCarloSimulation implements SimulationController {
         this.stats = this.optimizedSim.getStats();
         if (this.isLargeLattice()) {
           this.stateDirty = true;
+          // Main-thread fallback for a large lattice: emit so the large-aware UI
+          // handler pulls the raw snapshot and redraws (worker mode does this via
+          // onRawState instead). Without this the canvas would not animate.
+          this.emit('onStateChange', this.state as unknown as LatticeState);
         } else {
           this.state = this.optimizedSim.getState();
           if (this.state) {
@@ -451,21 +605,6 @@ export class MonteCarloSimulation implements SimulationController {
           await new Promise((resolve) => setTimeout(resolve, 0));
         }
       }
-    }
-    // Use worker if available
-    else if (this.workerSim) {
-      this.workerSim.run(steps);
-      // Wait for completion (handled by callbacks)
-      await new Promise((resolve) => {
-        const checkComplete = () => {
-          if (this.stats.step >= steps || !this.isRunningFlag) {
-            resolve(undefined);
-          } else {
-            setTimeout(checkComplete, 100);
-          }
-        };
-        checkComplete();
-      });
     }
     // Original implementation
     else {
@@ -495,6 +634,10 @@ export class MonteCarloSimulation implements SimulationController {
    */
   pause(): void {
     this.isPaused = true;
+    // Worker mode: halt the worker's continuous loop. step()/run() can restart it.
+    if (this.workerActive && this.workerSim) {
+      this.workerSim.stop();
+    }
   }
 
   /**
@@ -502,6 +645,9 @@ export class MonteCarloSimulation implements SimulationController {
    */
   resume(): void {
     this.isPaused = false;
+    if (this.workerActive && this.workerSim) {
+      this.workerSim.startContinuous(60);
+    }
   }
 
   /**
@@ -648,10 +794,8 @@ export class MonteCarloSimulation implements SimulationController {
     stats: SimulationStats;
     state: LatticeState;
   } {
-    if (!this.state) {
-      throw new Error('Simulation not initialized');
-    }
-
+    // getState() handles worker mode (rebuilds the object form from the cached
+    // raw snapshot) and the large optimized-engine case (rebuilds if stale).
     return {
       params: this.getParams(),
       stats: this.getStats(),
@@ -682,6 +826,28 @@ export class MonteCarloSimulation implements SimulationController {
     this.dims = { width: data.state.width, height: data.state.height };
     this.useOptimized = (this.config.useOptimized ?? true) && size > 8;
 
+    // Flatten the imported vertex types into the engine's typed-array state.
+    const typeToNum: Record<string, number> = { a1: 0, a2: 1, b1: 2, b2: 3, c1: 4, c2: 5 };
+    const flatten = (): Int8Array => {
+      const raw = new Int8Array(size * size);
+      for (let r = 0; r < size; r++) {
+        for (let c = 0; c < size; c++) {
+          raw[r * size + c] = typeToNum[data.state.vertices[r][c].type] ?? 0;
+        }
+      }
+      return raw;
+    };
+
+    // Worker mode: if a worker is already running for this lattice, adopt the
+    // imported config in the worker engine (zero-copy transfer of a fresh copy).
+    // The buffer is transferred, so send a copy we don't keep.
+    if (this.workerActive && this.workerSim && size > LARGE_LATTICE_THRESHOLD) {
+      this.workerSim.setState(flatten());
+      // Stats + a fresh rawState snapshot arrive via callbacks and refresh the
+      // cache; until then the cache may hold the pre-import snapshot.
+      return;
+    }
+
     if (this.useOptimized && !this.useWorker) {
       // Recreate the optimized engine, then load the imported configuration into
       // it (previously this was a no-op, so the engine kept a default DWBC state
@@ -694,15 +860,7 @@ export class MonteCarloSimulation implements SimulationController {
         initialState: data.params.dwbcConfig?.type === 'low' ? 'dwbc-low' : 'dwbc-high',
       });
 
-      // Flatten the imported vertex types into the engine's typed-array state.
-      const typeToNum: Record<string, number> = { a1: 0, a2: 1, b1: 2, b2: 3, c1: 4, c2: 5 };
-      const raw = new Int8Array(size * size);
-      for (let r = 0; r < size; r++) {
-        for (let c = 0; c < size; c++) {
-          raw[r * size + c] = typeToNum[data.state.vertices[r][c].type] ?? 0;
-        }
-      }
-      this.optimizedSim.setState(raw);
+      this.optimizedSim.setState(flatten());
       this.stats = this.optimizedSim.getStats();
     }
 

--- a/client/src/lib/six-vertex/types.ts
+++ b/client/src/lib/six-vertex/types.ts
@@ -235,6 +235,12 @@ export interface SimulationController {
   resume(): void;
   isRunning(): boolean;
 
+  /**
+   * Release background resources (e.g. terminate the Web Worker). Call when
+   * discarding a controller so worker threads don't leak across re-inits.
+   */
+  dispose?(): void;
+
   // Configuration
   updateParams(params: Partial<SimulationParams>): void;
   getParams(): SimulationParams;

--- a/client/src/lib/six-vertex/worker/simulationWorker.ts
+++ b/client/src/lib/six-vertex/worker/simulationWorker.ts
@@ -1,10 +1,28 @@
 /**
  * Web Worker for running the optimized simulation in a background thread
- * Allows the main thread to remain responsive while running large simulations
+ * Allows the main thread to remain responsive while running large simulations.
+ *
+ * State is exchanged as a compact, flat Int8Array (row-major, id = row*size+col;
+ * ids match cStyleFlipLogic a1=0..c2=5) and posted with the buffer in the
+ * transfer list. We NEVER post the object-graph LatticeState (~N*N objects),
+ * which is prohibitively expensive to structured-clone for large N.
  */
 
 import { OptimizedPhysicsSimulation } from '../optimizedSimulation';
 import type { OptimizedSimConfig } from '../optimizedSimulation';
+
+// The project tsconfig includes the DOM lib, so the global `self` is typed as a
+// Window whose postMessage(transfer) overload differs from the worker scope's.
+// At runtime this file only ever runs inside a DedicatedWorkerGlobalScope, so we
+// post through this narrowly-typed helper to get the transferable-list overload.
+const postToMain = (message: unknown, transfer?: Transferable[]): void => {
+  const post = self.postMessage as (msg: unknown, transfer?: Transferable[]) => void;
+  if (transfer && transfer.length > 0) {
+    post(message, transfer);
+  } else {
+    post(message);
+  }
+};
 
 // Message types for communication with main thread
 interface InitMessage {
@@ -15,6 +33,10 @@ interface InitMessage {
 interface RunMessage {
   type: 'run';
   steps: number;
+}
+
+interface StepMessage {
+  type: 'step';
 }
 
 interface StartContinuousMessage {
@@ -30,8 +52,13 @@ interface ResetMessage {
   type: 'reset';
 }
 
-interface GetStateMessage {
-  type: 'getState';
+interface GetRawStateMessage {
+  type: 'getRawState';
+}
+
+interface SetStateMessage {
+  type: 'setState';
+  vertices: Int8Array;
 }
 
 interface GetStatsMessage {
@@ -41,21 +68,27 @@ interface GetStatsMessage {
 type WorkerMessage =
   | InitMessage
   | RunMessage
+  | StepMessage
   | StartContinuousMessage
   | StopMessage
   | ResetMessage
-  | GetStateMessage
+  | GetRawStateMessage
+  | SetStateMessage
   | GetStatsMessage;
 
 // Response types
 interface StatsResponse {
   type: 'stats';
+  // The optimized engine returns a loosely-typed stats object (matches existing
+  // style); the main thread re-narrows it before handing it to consumers.
   stats: any;
 }
 
-interface StateResponse {
-  type: 'state';
-  state: any;
+interface RawStateResponse {
+  type: 'rawState';
+  vertices: Int8Array;
+  width: number;
+  height: number;
 }
 
 interface ErrorResponse {
@@ -75,7 +108,7 @@ interface ProgressResponse {
 
 type WorkerResponse =
   | StatsResponse
-  | StateResponse
+  | RawStateResponse
   | ErrorResponse
   | ReadyResponse
   | ProgressResponse;
@@ -84,6 +117,9 @@ type WorkerResponse =
 let simulation: OptimizedPhysicsSimulation | null = null;
 let continuousRunning = false;
 let animationFrame: number | null = null;
+// Batch size used for a single 'step' message and for continuous animate ticks.
+// Kept in sync with the engine's configured batchSize when available.
+let stepBatchSize = 100;
 
 /**
  * Handle messages from the main thread
@@ -101,6 +137,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
         handleRun(message.steps);
         break;
 
+      case 'step':
+        handleStep();
+        break;
+
       case 'startContinuous':
         handleStartContinuous(message.targetFPS);
         break;
@@ -113,8 +153,12 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
         handleReset();
         break;
 
-      case 'getState':
-        handleGetState();
+      case 'getRawState':
+        handleGetRawState();
+        break;
+
+      case 'setState':
+        handleSetState(message.vertices);
         break;
 
       case 'getStats':
@@ -134,8 +178,10 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
  */
 function handleInit(config: OptimizedSimConfig): void {
   simulation = new OptimizedPhysicsSimulation(config);
+  stepBatchSize = config.batchSize && config.batchSize > 0 ? config.batchSize : 100;
   sendResponse({ type: 'ready' });
-  sendResponse({ type: 'stats', stats: simulation.getStats() });
+  sendStats();
+  sendRawState();
 }
 
 /**
@@ -163,7 +209,22 @@ function handleRun(steps: number): void {
     });
   }
 
-  sendResponse({ type: 'stats', stats: simulation.getStats() });
+  sendStats();
+  sendRawState();
+}
+
+/**
+ * Run a single batch of steps (used for step-by-step control).
+ */
+function handleStep(): void {
+  if (!simulation) {
+    sendError('Simulation not initialized');
+    return;
+  }
+
+  simulation.run(stepBatchSize);
+  sendStats();
+  sendRawState();
 }
 
 /**
@@ -196,11 +257,10 @@ function handleStartContinuous(targetFPS: number): void {
       // Run the simulation
       simulation.run(stepsPerFrame);
 
-      // Send stats update
-      sendResponse({
-        type: 'stats',
-        stats: simulation.getStats(),
-      });
+      // Send stats + a raw snapshot for rendering. One snapshot per animate tick
+      // is acceptable: rendering (not transfer) is the main-thread bottleneck.
+      sendStats();
+      sendRawState();
 
       lastTime = currentTime;
     }
@@ -234,19 +294,33 @@ function handleReset(): void {
   }
 
   simulation.reset();
-  sendResponse({ type: 'stats', stats: simulation.getStats() });
+  sendStats();
+  sendRawState();
 }
 
 /**
- * Get current state
+ * Send the current raw state on demand.
  */
-function handleGetState(): void {
+function handleGetRawState(): void {
   if (!simulation) {
     sendError('Simulation not initialized');
     return;
   }
+  sendRawState();
+}
 
-  sendResponse({ type: 'state', state: simulation.getState() });
+/**
+ * Adopt an externally-supplied state (e.g. an imported configuration).
+ * The transferred buffer is owned by the worker after this message.
+ */
+function handleSetState(vertices: Int8Array): void {
+  if (!simulation) {
+    sendError('Simulation not initialized');
+    return;
+  }
+  simulation.setState(vertices);
+  sendStats();
+  sendRawState();
 }
 
 /**
@@ -257,15 +331,40 @@ function handleGetStats(): void {
     sendError('Simulation not initialized');
     return;
   }
+  sendStats();
+}
 
+/**
+ * Post the current stats to the main thread.
+ */
+function sendStats(): void {
+  if (!simulation) return;
   sendResponse({ type: 'stats', stats: simulation.getStats() });
 }
 
 /**
- * Send response to main thread
+ * Post a fresh raw-state snapshot, transferring its backing buffer so no copy is
+ * made during structured clone. getRawState() already returns a fresh copy, so
+ * the engine keeps ownership of its own vertices array.
+ */
+function sendRawState(): void {
+  if (!simulation) return;
+  const vertices = new Int8Array(simulation.getRawState());
+  const size = simulation.getSize();
+  const resp: RawStateResponse = {
+    type: 'rawState',
+    vertices,
+    width: size,
+    height: size,
+  };
+  postToMain(resp, [resp.vertices.buffer]);
+}
+
+/**
+ * Send response to main thread (no transfer list)
  */
 function sendResponse(response: WorkerResponse): void {
-  self.postMessage(response);
+  postToMain(response);
 }
 
 /**

--- a/client/src/lib/six-vertex/worker/workerInterface.ts
+++ b/client/src/lib/six-vertex/worker/workerInterface.ts
@@ -1,6 +1,9 @@
 /**
  * Main thread interface for the simulation Web Worker
- * Provides a clean API for controlling the simulation running in a background thread
+ * Provides a clean API for controlling the simulation running in a background thread.
+ *
+ * State crosses the boundary as a compact Int8Array carried on a transferable
+ * ArrayBuffer (both directions), never as the object-graph LatticeState.
  */
 
 import type { OptimizedSimConfig } from '../optimizedSimulation';
@@ -8,7 +11,7 @@ import type { WorkerMessage, WorkerResponse } from './simulationWorker';
 
 export interface WorkerSimulationCallbacks {
   onStats?: (stats: any) => void;
-  onState?: (state: any) => void;
+  onRawState?: (vertices: Int8Array, width: number, height: number) => void;
   onProgress?: (progress: number, stats: any) => void;
   onError?: (error: string) => void;
   onReady?: () => void;
@@ -21,7 +24,7 @@ export class WorkerSimulation {
   private worker: Worker | null = null;
   private callbacks: WorkerSimulationCallbacks = {};
   private isInitialized = false;
-  private pendingMessages: WorkerMessage[] = [];
+  private pendingMessages: { message: WorkerMessage; transfer?: Transferable[] }[] = [];
 
   constructor(callbacks?: WorkerSimulationCallbacks) {
     if (callbacks) {
@@ -59,9 +62,9 @@ export class WorkerSimulation {
 
         // Process any pending messages
         while (this.pendingMessages.length > 0) {
-          const msg = this.pendingMessages.shift();
-          if (msg) {
-            this.sendMessage(msg);
+          const pending = this.pendingMessages.shift();
+          if (pending) {
+            this.sendMessage(pending.message, pending.transfer);
           }
         }
 
@@ -87,6 +90,14 @@ export class WorkerSimulation {
   }
 
   /**
+   * Run a single batch of steps (step-by-step control). Updates arrive via the
+   * onStats / onRawState callbacks.
+   */
+  step(): void {
+    this.sendMessage({ type: 'step' });
+  }
+
+  /**
    * Start continuous simulation
    */
   startContinuous(targetFPS: number = 60): void {
@@ -108,10 +119,18 @@ export class WorkerSimulation {
   }
 
   /**
-   * Request current state
+   * Request the current raw state. The response arrives via onRawState.
    */
-  getState(): void {
-    this.sendMessage({ type: 'getState' });
+  getRawState(): void {
+    this.sendMessage({ type: 'getRawState' });
+  }
+
+  /**
+   * Adopt an externally-supplied state in the worker engine. The buffer is
+   * transferred (zero-copy), so the caller must pass a buffer it no longer uses.
+   */
+  setState(vertices: Int8Array): void {
+    this.sendMessage({ type: 'setState', vertices }, [vertices.buffer]);
   }
 
   /**
@@ -142,18 +161,22 @@ export class WorkerSimulation {
   /**
    * Send message to worker
    */
-  private sendMessage(message: WorkerMessage): void {
+  private sendMessage(message: WorkerMessage, transfer?: Transferable[]): void {
     if (!this.worker) {
       throw new Error('Worker not initialized');
     }
 
     if (!this.isInitialized && message.type !== 'init') {
       // Queue message until initialized
-      this.pendingMessages.push(message);
+      this.pendingMessages.push({ message, transfer });
       return;
     }
 
-    this.worker.postMessage(message);
+    if (transfer && transfer.length > 0) {
+      this.worker.postMessage(message, transfer);
+    } else {
+      this.worker.postMessage(message);
+    }
   }
 
   /**
@@ -169,9 +192,9 @@ export class WorkerSimulation {
         }
         break;
 
-      case 'state':
-        if (this.callbacks.onState) {
-          this.callbacks.onState(response.state);
+      case 'rawState':
+        if (this.callbacks.onRawState) {
+          this.callbacks.onRawState(response.vertices, response.width, response.height);
         }
         break;
 

--- a/client/src/routes/performanceDemo.tsx
+++ b/client/src/routes/performanceDemo.tsx
@@ -97,13 +97,12 @@ export function PerformanceDemo() {
         {
           onStats: (stats) => {
             setSimulationStats(stats);
-            if (rendererRef.current && simRef.current) {
-              simRef.current.getState();
-            }
           },
-          onState: (state) => {
-            if (rendererRef.current) {
-              rendererRef.current.render(state);
+          // The worker now pushes a compact typed-array snapshot (not the object
+          // graph). Render it via the fast bitmap path.
+          onRawState: (vertices: Int8Array, width: number, height: number) => {
+            if (rendererRef.current?.renderRaw) {
+              rendererRef.current.renderRaw(width, height, vertices);
             }
           },
         },

--- a/client/tests/six-vertex/rawState.test.ts
+++ b/client/tests/six-vertex/rawState.test.ts
@@ -46,6 +46,40 @@ describe('getRawState (typed-array snapshot)', () => {
     }
   });
 
+  // The Web Worker boundary relies on two engine guarantees: setState() adopts an
+  // external Int8Array exactly, and getRawState() returns a FRESH copy (so the
+  // engine keeps ownership when the worker transfers its buffer). We verify those
+  // semantics directly here; the worker message wiring itself (import.meta.url,
+  // transferables) is verified in-browser since ts-jest cannot load the worker.
+  it('setState + getRawState round-trips exactly and returns a fresh copy', () => {
+    const N = 16;
+    const sim = new OptimizedPhysicsSimulation({ size: N, weights: WEIGHTS, seed: 99 });
+
+    // Build a valid configuration to import (use a fresh engine's DWBC-low state).
+    const source = new OptimizedPhysicsSimulation({
+      size: N,
+      weights: WEIGHTS,
+      seed: 1,
+      initialState: 'dwbc-low',
+    });
+    const imported = source.getRawState();
+
+    sim.setState(imported);
+    const after = sim.getRawState();
+
+    expect(after.length).toBe(imported.length);
+    for (let i = 0; i < imported.length; i++) {
+      expect(after[i]).toBe(imported[i]);
+    }
+
+    // getRawState() must be a copy: mutating it must not corrupt engine state,
+    // which is what makes transferring the returned buffer safe in the worker.
+    after[0] = (after[0] + 1) % 6;
+    const again = sim.getRawState();
+    expect(again[0]).toBe(imported[0]);
+    expect(again[0]).not.toBe(after[0]);
+  });
+
   it('handles large lattices (1024) and stays consistent after stepping', () => {
     const N = 1024;
     const sim = new OptimizedPhysicsSimulation({ size: N, weights: WEIGHTS, seed: 7 });


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-66.dev.6v.allison.la

## Summary
Large lattices ran the Monte Carlo loop on the main thread, blocking the UI. The engine now runs in a **Web Worker** above the large-lattice threshold (N > 128), exchanging compact `Int8Array` state over **transferable `ArrayBuffer`s** (never the object-graph `LatticeState`), keeping the UI at interactive frame rates. Small lattices stay fully synchronous on the main thread (step-by-step debugging + object renderer unchanged). Part of EPIC #54.

## Changes
- **Worker protocol** (`simulationWorker.ts` / `workerInterface.ts`): replaced the object-graph `getState` path with a raw path — `getRawState → rawState` posted with the buffer in the transfer list (fresh copy, engine keeps ownership). `init`/`step`/`run`/`reset`/`startContinuous` also push a raw snapshot for rendering. New `setState` (adopts a transferred buffer, used by import) and `step` (one configured batch) messages. Interface gains `onRawState` + `getRawState`/`setState`/`step`; the pending-message queue carries transfer lists.
- **Facade async-cache model** (`simulation.ts`): the worker is the source of truth in worker mode; the facade caches the latest raw snapshot + stats from callbacks and serves them from `getRawState()`/`getStats()`. `getState()` lazily rebuilds the object form on demand (save/export) using the canonical `getVertexConfiguration` mapping. Worker gated to opt-in **AND** `size > LARGE_LATTICE_THRESHOLD` **AND** `isWorkerSupported()`. `step`/`run`/`pause`/`resume`/`reset`/`importData` all proxy to the worker. A `pendingRun` flag honours Run pressed before the async worker is ready (instead of throwing); clean `fallBackToOptimized` when workers are unavailable; new `dispose()` terminates the worker.
- **MainSimulator**: `useWorker: true` (facade gates internally); large lattices hand off to `run()` once (worker self-drives, redraws via the large-aware `onStateChange → getRawState → renderRaw`); the init effect and `initializeSimulation` now **dispose the replaced controller** so worker threads don't leak across re-inits.

## Reproducibility
The worker constructs the same `OptimizedPhysicsSimulation` (size/weights/seed) and the main-thread engine is not stepped when the worker is active.

## Testing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean (pre-existing `any`-warnings only)
- [x] `npx jest --ci` — **317/317** pass (added a `setState`+`getRawState` ownership round-trip test)
- [x] `npm run build` passes (worker emitted as its own chunk)
- [x] **In-browser**: 456×456 lattice runs at **60fps**, UI responsive (~17ms frames); worker run **byte-identical** to the main-thread engine for the same seed (**0/25600** mismatches); **import-with-worker** adopts the imported config exactly (**0/25600**); Pause/Step/Reset transitions correct; no crash; `dispose()` terminates the worker
- [ ] Preview deployment tested

## Related Issues
Refs #56 (EPIC #54)

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Ice rule / reproducibility preserved
- [x] CI checks pass
- [x] Preview link included
