### PR TITLE
feat: unified N-simulation system with stop/convergence conditions (#58)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { PerformanceDemo } from './routes/performanceDemo';
 import { DWBCDebug } from './routes/dwbcDebug';
 import { FlipDebug } from './routes/flipDebug';
 import { DualSimulation } from './routes/dualSimulation';
+import { NSimulation } from './routes/nSimulation';
 import { HeightDemo } from './routes/heightDemo';
 import ErrorBoundary from './components/ErrorBoundary';
 import { ThemeToggle } from './components/ThemeToggle';
@@ -69,6 +70,9 @@ function App() {
                 <NavLink to="/dual-simulation" className="nav-link">
                   Compare High vs Low
                 </NavLink>
+                <NavLink to="/n-simulation" className="nav-link">
+                  Compare N Sims
+                </NavLink>
                 <NavLink to="/height-demo" className="nav-link">
                   Height Function
                 </NavLink>
@@ -110,6 +114,7 @@ function App() {
             <Route path="/dwbc-debug" element={<DWBCDebug />} />
             <Route path="/flip-debug" element={<FlipDebug />} />
             <Route path="/dual-simulation" element={<DualSimulation />} />
+            <Route path="/n-simulation" element={<NSimulation />} />
             <Route path="/height-demo" element={<HeightDemo />} />
             <Route path="/performance" element={<PerformanceDemo />} />
           </Routes>

--- a/client/src/lib/six-vertex/nSimulation.ts
+++ b/client/src/lib/six-vertex/nSimulation.ts
@@ -1,0 +1,199 @@
+/**
+ * N-simulation manager: orchestrates an arbitrary number of independent
+ * 6-vertex Monte Carlo simulations that share lattice size / temperature /
+ * weights but differ in initial condition and seed, and tracks how their
+ * macroscopic observables converge.
+ *
+ * This is the unified core that subsumes the single (N=1) and dual (N=2)
+ * cases. It is engine- and UI-agnostic: it builds one SimulationController per
+ * instance via createSimulation, exposes those controllers so a React route can
+ * subscribe for redraws, and keeps per-instance observable history plus a
+ * StopContext for evaluating composable stop conditions.
+ *
+ * Worker-async model (matches simulation.ts): for large lattices each
+ * controller runs its Monte Carlo loop in a Web Worker and pushes stats + raw
+ * snapshots via events. The manager does NOT poll the workers; the route drives
+ * a requestAnimationFrame tick that subscribes to each controller (for redraw),
+ * and periodically calls pushHistory() + evaluateStop(). getSnapshots()/getStats
+ * read each controller's synchronous cache, which the worker keeps fresh.
+ */
+
+import { createSimulation, LARGE_LATTICE_THRESHOLD } from './simulation';
+import type { SimulationConfig } from './simulation';
+import { BoundaryCondition } from './types';
+import type { SimulationController, SimulationParams } from './types';
+import { heightObservable, relativeSpread } from './stopConditions';
+import type { NSimSnapshot, StopContext, StopPredicate } from './stopConditions';
+
+export type NSimInitialState = 'dwbc-high' | 'dwbc-low' | 'random';
+
+export interface NSimInstanceConfig {
+  id: string;
+  label: string;
+  initialState: NSimInitialState;
+  seed: number;
+}
+
+export interface NSimWeights {
+  a1: number;
+  a2: number;
+  b1: number;
+  b2: number;
+  c1: number;
+  c2: number;
+}
+
+export interface NSimConfig {
+  size: number;
+  temperature: number;
+  weights: NSimWeights;
+  instances: NSimInstanceConfig[];
+}
+
+/** Cap on per-instance observable history so memory stays bounded over a long run. */
+const MAX_HISTORY = 200;
+
+const WORKER_CONFIG: SimulationConfig = {
+  useOptimized: true,
+  useWorker: true,
+  workerThreshold: 50,
+};
+
+function paramsForInstance(config: NSimConfig, instance: NSimInstanceConfig): SimulationParams {
+  const isDwbc = instance.initialState !== 'random';
+  return {
+    temperature: config.temperature,
+    beta: 1.0 / config.temperature,
+    weights: { ...config.weights },
+    boundaryCondition: isDwbc ? BoundaryCondition.DWBC : BoundaryCondition.Open,
+    dwbcConfig: isDwbc
+      ? { type: instance.initialState === 'dwbc-high' ? 'high' : 'low' }
+      : undefined,
+    seed: instance.seed,
+  };
+}
+
+export class NSimulationManager {
+  private config: NSimConfig;
+  private controllers: SimulationController[] = [];
+  private history: number[][] = [];
+
+  constructor(config: NSimConfig) {
+    this.config = { ...config, weights: { ...config.weights }, instances: [...config.instances] };
+    this.build();
+  }
+
+  private build(): void {
+    this.controllers = this.config.instances.map((instance) => {
+      const params = paramsForInstance(this.config, instance);
+      const controller = createSimulation(params, WORKER_CONFIG);
+      controller.initialize(this.config.size, this.config.size, params);
+      return controller;
+    });
+    this.history = this.config.instances.map(() => []);
+  }
+
+  /** Expose the controllers so the route can subscribe for per-instance redraws. */
+  getControllers(): SimulationController[] {
+    return this.controllers;
+  }
+
+  getInstanceConfigs(): NSimInstanceConfig[] {
+    return this.config.instances;
+  }
+
+  getSize(): number {
+    return this.config.size;
+  }
+
+  /** Large lattices render via the raw bitmap path rather than the object form. */
+  isLarge(): boolean {
+    return this.config.size > LARGE_LATTICE_THRESHOLD;
+  }
+
+  /** Step every instance once. */
+  step(): void {
+    for (const controller of this.controllers) {
+      controller.step();
+    }
+  }
+
+  /** Start every instance running (worker continuous loop for large lattices). */
+  run(): void {
+    for (const controller of this.controllers) {
+      void controller.run(Number.MAX_SAFE_INTEGER);
+    }
+  }
+
+  pause(): void {
+    for (const controller of this.controllers) {
+      controller.pause();
+    }
+  }
+
+  /** Reset every instance to its seeded initial state and clear history. */
+  reset(): void {
+    for (const controller of this.controllers) {
+      controller.reset();
+    }
+    this.history = this.config.instances.map(() => []);
+  }
+
+  /** Terminate every controller (and its Web Worker) so nothing leaks. */
+  dispose(): void {
+    for (const controller of this.controllers) {
+      controller.dispose?.();
+    }
+    this.controllers = [];
+  }
+
+  /** Latest step + observable + stats for each instance. */
+  getSnapshots(): NSimSnapshot[] {
+    return this.controllers.map((controller) => {
+      const stats = controller.getStats();
+      return { step: stats.step, observable: heightObservable(stats), stats };
+    });
+  }
+
+  /** Append the current observables to each instance's history (capped). */
+  pushHistory(): void {
+    const snapshots = this.getSnapshots();
+    for (let i = 0; i < snapshots.length; i++) {
+      if (!this.history[i]) this.history[i] = [];
+      const series = this.history[i];
+      series.push(snapshots[i].observable);
+      if (series.length > MAX_HISTORY) {
+        series.shift();
+      }
+    }
+  }
+
+  /** Copy of the per-instance observable history (oldest -> newest). */
+  getHistory(): number[][] {
+    return this.history.map((series) => [...series]);
+  }
+
+  /** Current cross-instance relative spread (the live convergence readout). */
+  getRelativeSpread(): number {
+    const observables = this.getSnapshots().map((s) => s.observable);
+    return relativeSpread(observables);
+  }
+
+  /** Max step across instances (used as the global step for stop conditions). */
+  getStep(): number {
+    return this.getSnapshots().reduce((max, s) => Math.max(max, s.step), 0);
+  }
+
+  private buildStopContext(): StopContext {
+    return {
+      step: this.getStep(),
+      instances: this.getSnapshots(),
+      history: this.history,
+    };
+  }
+
+  /** Evaluate a stop predicate against the current snapshots + history. */
+  evaluateStop(predicate: StopPredicate): boolean {
+    return predicate(this.buildStopContext());
+  }
+}

--- a/client/src/lib/six-vertex/stopConditions.ts
+++ b/client/src/lib/six-vertex/stopConditions.ts
@@ -1,0 +1,160 @@
+/**
+ * Composable stop / convergence conditions for the N-simulation system.
+ *
+ * Everything here is a PURE function over a snapshot context so the conditions
+ * are trivially unit-testable without spinning up any Monte Carlo engine. The
+ * N-simulation manager (nSimulation.ts) builds a StopContext from its live
+ * controllers and evaluates a StopPredicate each tick; the route surfaces the
+ * result (auto-stop + "Converged at step N" badge).
+ */
+
+import type { SimulationStats } from './types';
+
+/** Latest observed sample for a single simulation instance. */
+export interface NSimSnapshot {
+  step: number;
+  observable: number;
+  stats: SimulationStats;
+}
+
+/**
+ * Everything a stop predicate needs to decide. `instances` is the latest
+ * snapshot per instance (parallel to `history`); `history` is the per-instance
+ * observable history (oldest -> newest), one inner array per instance.
+ */
+export interface StopContext {
+  step: number;
+  instances: NSimSnapshot[];
+  history: number[][];
+}
+
+export type StopPredicate = (ctx: StopContext) => boolean;
+
+/** A user-selectable stop condition with display metadata. */
+export interface StopConditionDescriptor {
+  id: string;
+  label: string;
+  predicate: StopPredicate;
+}
+
+/** Avoid division-by-zero when the observable mean is ~0. */
+const EPSILON = 1e-9;
+
+/**
+ * Macroscopic observable used to compare instances. Prefers the engine-reported
+ * height when present, otherwise falls back to the c2 vertex count. This is a
+ * COARSE proxy for the macroscopic configuration (height ~ Arctic-curve volume);
+ * relative spread (below) handles its scale, so no normalization is needed.
+ */
+export function heightObservable(stats: SimulationStats): number {
+  if (typeof stats.height === 'number') {
+    return stats.height;
+  }
+  return stats.vertexCounts.c2;
+}
+
+/**
+ * Relative spread of a set of values: (max - min) / max(mean, EPSILON).
+ * 0 means all equal; larger means more disagreement. Scale-free, so it works
+ * across lattice sizes without normalizing the observable.
+ */
+export function relativeSpread(values: number[]): number {
+  if (values.length === 0) return 0;
+  let min = values[0];
+  let max = values[0];
+  let sum = 0;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+  }
+  const mean = sum / values.length;
+  return (max - min) / Math.max(Math.abs(mean), EPSILON);
+}
+
+/** Stop once the (max/global) step count reaches `n`. */
+export function maxSteps(n: number): StopConditionDescriptor {
+  return {
+    id: 'max-steps',
+    label: `Max steps (${n})`,
+    predicate: (ctx) => ctx.step >= n,
+  };
+}
+
+/**
+ * Stop once every instance's observable has stayed mutually tight (relative
+ * spread <= threshold) for an entire window of recent samples. Requires:
+ *  - at least 2 instances (one sim cannot "converge with others");
+ *  - at least `window` samples of history (so it can't fire before warming up);
+ *  - the cross-instance relative spread to be <= threshold for EVERY one of the
+ *    last `window` samples (a single brief dip is not enough).
+ */
+export function allConverged(
+  options: { threshold?: number; window?: number } = {},
+): StopConditionDescriptor {
+  const threshold = options.threshold ?? 0.05;
+  const window = options.window ?? 30;
+  return {
+    id: 'all-converged',
+    label: `All converged (≤${(threshold * 100).toFixed(0)}% over ${window})`,
+    predicate: (ctx) => {
+      const series = ctx.history;
+      if (series.length < 2) return false;
+      const lengths = series.map((s) => s.length);
+      const minLen = Math.min(...lengths);
+      if (minLen < window) return false;
+
+      for (let offset = 0; offset < window; offset++) {
+        const idx = (len: number) => len - window + offset;
+        const sample = series.map((s) => s[idx(s.length)]);
+        if (relativeSpread(sample) > threshold) {
+          return false;
+        }
+      }
+      return true;
+    },
+  };
+}
+
+/**
+ * Early bail-out: stop the moment the CURRENT cross-instance relative spread
+ * reaches `threshold` (e.g. instances are diverging and there's no point
+ * continuing). Needs >=2 instances.
+ */
+export function divergenceExceeded(options: { threshold: number }): StopConditionDescriptor {
+  const { threshold } = options;
+  return {
+    id: 'divergence-exceeded',
+    label: `Divergence ≥${(threshold * 100).toFixed(0)}%`,
+    predicate: (ctx) => {
+      if (ctx.instances.length < 2) return false;
+      const current = ctx.instances.map((s) => s.observable);
+      return relativeSpread(current) >= threshold;
+    },
+  };
+}
+
+/** Never stops on its own; the user stops the run manually. */
+export function manual(): StopConditionDescriptor {
+  return {
+    id: 'manual',
+    label: 'Manual (run until stopped)',
+    predicate: () => false,
+  };
+}
+
+/**
+ * Combine predicates. `'any'` stops when at least one fires (logical OR);
+ * `'all'` stops only when every predicate fires (logical AND). An empty list
+ * never stops (any => false, all => vacuously... treated as never-stop so a
+ * UI with no conditions selected keeps running).
+ */
+export function combineStop(predicates: StopPredicate[], mode: 'any' | 'all'): StopPredicate {
+  return (ctx) => {
+    if (predicates.length === 0) return false;
+    if (mode === 'any') {
+      return predicates.some((p) => p(ctx));
+    }
+    return predicates.every((p) => p(ctx));
+  };
+}

--- a/client/src/routes/nSimulation.module.css
+++ b/client/src/routes/nSimulation.module.css
@@ -1,0 +1,134 @@
+/* N-simulation route styling. Token-based so light/dark themes work for free. */
+
+.page {
+  padding: var(--spacing-xl);
+}
+
+.panel {
+  background: var(--panel-bg);
+  padding: var(--spacing-xl);
+  border-radius: var(--border-radius-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
+.controlsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--spacing-md);
+}
+
+.weightsSection {
+  margin-top: var(--spacing-xl);
+}
+
+.weightsGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-sm);
+}
+
+.actionButtons {
+  margin-top: var(--spacing-xl);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.badge {
+  margin-left: auto;
+  padding: var(--spacing-xs) var(--spacing-md);
+  border-radius: var(--border-radius-lg);
+  font-weight: var(--font-weight-bold);
+  background: var(--color-success);
+  color: #fff;
+}
+
+.instancesSection {
+  margin-top: var(--spacing-xl);
+}
+
+.instanceRow {
+  display: grid;
+  grid-template-columns: 1fr auto auto auto;
+  gap: var(--spacing-sm);
+  align-items: center;
+  margin-bottom: var(--spacing-sm);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--spacing-lg);
+  margin-bottom: var(--spacing-xl);
+}
+
+.instanceCard {
+  background: var(--panel-bg);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-md);
+  display: flex;
+  flex-direction: column;
+}
+
+.instanceHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--spacing-sm);
+}
+
+.instanceTitle {
+  font-weight: var(--font-weight-semibold);
+}
+
+.instanceMeta {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.canvasHolder {
+  position: relative;
+  height: 260px;
+  background: var(--canvas-bg, var(--panel-bg));
+  border-radius: var(--border-radius-md);
+  overflow: hidden;
+}
+
+.instanceObservable {
+  margin-top: var(--spacing-sm);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.convergencePanel {
+  margin-top: 0;
+  margin-bottom: var(--spacing-xl);
+  padding: var(--spacing-md) var(--spacing-xl);
+  background: var(--panel-bg);
+  border-radius: var(--border-radius-lg);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--spacing-sm);
+  align-items: center;
+}
+
+.metricLabel {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+}
+
+.metricValue {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-semibold);
+}
+
+.statusValue {
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-secondary);
+}
+
+.statusConverged {
+  color: var(--color-success);
+}

--- a/client/src/routes/nSimulation.tsx
+++ b/client/src/routes/nSimulation.tsx
@@ -1,0 +1,631 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { PageShell } from '../components/PageShell';
+import VisualizationCanvas from '../components/VisualizationCanvas';
+import { PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
+import { NSimulationManager } from '../lib/six-vertex/nSimulation';
+import type {
+  NSimConfig,
+  NSimInitialState,
+  NSimInstanceConfig,
+  NSimWeights,
+} from '../lib/six-vertex/nSimulation';
+import { LARGE_LATTICE_THRESHOLD } from '../lib/six-vertex/simulation';
+import { RenderMode } from '../lib/six-vertex/types';
+import type {
+  LatticeState,
+  RawLatticeState,
+  RenderConfig,
+  SimulationController,
+  SimulationStats,
+} from '../lib/six-vertex/types';
+import { getThemeColors } from '../lib/six-vertex/themeColors';
+import { useTheme } from '../hooks/useTheme';
+import {
+  allConverged,
+  combineStop,
+  manual,
+  maxSteps,
+  type StopPredicate,
+} from '../lib/six-vertex/stopConditions';
+import '../App.css';
+import styles from './nSimulation.module.css';
+
+type StopMode = 'manual' | 'max-steps' | 'all-converged';
+
+const MAX_INSTANCES = 6;
+const INITIAL_STATE_LABELS: Record<NSimInitialState, string> = {
+  'dwbc-high': 'DWBC High',
+  'dwbc-low': 'DWBC Low',
+  random: 'Random',
+};
+
+let instanceCounter = 0;
+function makeInstance(initialState: NSimInitialState, label: string): NSimInstanceConfig {
+  instanceCounter += 1;
+  return {
+    id: `inst-${instanceCounter}`,
+    label,
+    initialState,
+    seed: 10000 + Math.floor(Math.random() * 90000),
+  };
+}
+
+function defaultInstances(): NSimInstanceConfig[] {
+  return [makeInstance('dwbc-high', 'Sim 1 · High'), makeInstance('dwbc-low', 'Sim 2 · Low')];
+}
+
+/**
+ * One simulation instance: owns its PathRenderer (stable per-instance ref) and
+ * subscribes to its controller for redraws. Large lattices render via the raw
+ * bitmap path (pulled in onStateChange), small ones via the object form —
+ * mirroring MainSimulator's large-aware handling and stable onRendererReady.
+ */
+function InstancePanel({
+  controller,
+  label,
+  initialState,
+  seed,
+  isLarge,
+  renderConfig,
+  observable,
+}: {
+  controller: SimulationController;
+  label: string;
+  initialState: NSimInitialState;
+  seed: number;
+  isLarge: boolean;
+  renderConfig: Partial<RenderConfig>;
+  observable: number;
+}) {
+  const rendererRef = useRef<PathRenderer | null>(null);
+  const [latticeState, setLatticeState] = useState<LatticeState | null>(null);
+  const [rawState, setRawState] = useState<RawLatticeState | null>(null);
+
+  const isLargeRef = useRef(isLarge);
+  isLargeRef.current = isLarge;
+  const latticeStateRef = useRef<LatticeState | null>(null);
+  latticeStateRef.current = latticeState;
+  const rawStateRef = useRef<RawLatticeState | null>(null);
+  rawStateRef.current = rawState;
+
+  // Seed the canvas with the controller's current state, then subscribe for
+  // updates. Re-runs only when the controller instance changes (Apply/Reset),
+  // not every frame.
+  useEffect(() => {
+    if (isLargeRef.current) {
+      setLatticeState(null);
+      const raw = controller.getRawState();
+      if (raw) {
+        setRawState(raw);
+        rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+      }
+    } else {
+      setRawState(null);
+      try {
+        const state = controller.getState();
+        setLatticeState(state);
+        rendererRef.current?.render(state);
+      } catch {
+        // Worker mode may not have an object state yet; the onStateChange
+        // handler will fill it in once the first snapshot arrives.
+      }
+    }
+
+    const handleStateChange = (state: LatticeState) => {
+      if (isLargeRef.current) {
+        const raw = controller.getRawState();
+        if (raw) {
+          setRawState(raw);
+          rendererRef.current?.renderRaw(raw.width, raw.height, raw.vertices);
+        }
+      } else {
+        setLatticeState(state);
+        rendererRef.current?.render(state);
+      }
+    };
+
+    controller.on('onStateChange', handleStateChange);
+    return () => {
+      controller.off('onStateChange', handleStateChange);
+    };
+  }, [controller]);
+
+  // Stable identity (empty deps + refs) so VisualizationCanvas does not recreate
+  // the PathRenderer every frame (that bug crashed the tab for large lattices).
+  const handleRendererReady = useCallback((renderer: PathRenderer) => {
+    rendererRef.current = renderer;
+    const raw = rawStateRef.current;
+    if (raw) {
+      renderer.renderRaw(raw.width, raw.height, raw.vertices);
+    } else if (latticeStateRef.current) {
+      renderer.render(latticeStateRef.current);
+    }
+  }, []);
+
+  return (
+    <div className={styles.instanceCard}>
+      <div className={styles.instanceHeader}>
+        <span className={styles.instanceTitle}>{label}</span>
+        <span className={styles.instanceMeta}>
+          {INITIAL_STATE_LABELS[initialState]} · seed {seed}
+        </span>
+      </div>
+      <div className={styles.canvasHolder}>
+        <VisualizationCanvas
+          renderer={rendererRef.current}
+          latticeState={isLarge ? null : latticeState}
+          rawState={isLarge ? rawState : null}
+          onRendererReady={handleRendererReady}
+          renderConfig={renderConfig}
+        />
+      </div>
+      <div className={styles.instanceObservable}>Observable (height): {observable.toFixed(2)}</div>
+    </div>
+  );
+}
+
+export function NSimulation() {
+  const { theme } = useTheme();
+  const isDarkMode = theme === 'dark';
+  const labelPrefix = useId();
+
+  // Draft config (edited by the controls). Apply rebuilds the manager from it.
+  const [size, setSize] = useState(16);
+  const [temperature, setTemperature] = useState(1.0);
+  const [weights, setWeights] = useState<NSimWeights>({
+    a1: 1,
+    a2: 1,
+    b1: 1,
+    b2: 1,
+    c1: 1,
+    c2: 1,
+  });
+  const [stepsPerFrame, setStepsPerFrame] = useState(20);
+  const [instances, setInstances] = useState<NSimInstanceConfig[]>(defaultInstances);
+
+  // Stop-condition selection.
+  const [stopMode, setStopMode] = useState<StopMode>('all-converged');
+  const [maxStepsValue, setMaxStepsValue] = useState(50000);
+  const [convergenceThreshold, setConvergenceThreshold] = useState(0.05);
+
+  // Live state surfaced to the UI.
+  const [controllers, setControllers] = useState<SimulationController[]>([]);
+  const [activeInstances, setActiveInstances] = useState<NSimInstanceConfig[]>([]);
+  const [isLargeActive, setIsLargeActive] = useState(false);
+  const [isRunning, setIsRunning] = useState(false);
+  const [spread, setSpread] = useState(0);
+  const [snapshots, setSnapshots] = useState<SimulationStats[]>([]);
+  const [convergedAtStep, setConvergedAtStep] = useState<number | null>(null);
+
+  const managerRef = useRef<NSimulationManager | null>(null);
+  const animationFrameRef = useRef<number | null>(null);
+  const isRunningRef = useRef(false);
+  isRunningRef.current = isRunning;
+
+  // Build the active stop predicate from the current selection.
+  const stopPredicate = useMemo<StopPredicate>(() => {
+    switch (stopMode) {
+      case 'max-steps':
+        return maxSteps(maxStepsValue).predicate;
+      case 'all-converged':
+        return combineStop(
+          [allConverged({ threshold: convergenceThreshold, window: 30 }).predicate],
+          'any',
+        );
+      case 'manual':
+      default:
+        return manual().predicate;
+    }
+  }, [stopMode, maxStepsValue, convergenceThreshold]);
+  const stopPredicateRef = useRef(stopPredicate);
+  stopPredicateRef.current = stopPredicate;
+
+  const refreshReadouts = useCallback(() => {
+    const manager = managerRef.current;
+    if (!manager) return;
+    setSpread(manager.getRelativeSpread());
+    setSnapshots(manager.getSnapshots().map((s) => s.stats));
+  }, []);
+
+  // Build (or rebuild) the manager from the current draft config.
+  const applyConfig = useCallback(() => {
+    // Stop the run loop and tear down the old manager (terminates its workers).
+    if (animationFrameRef.current) {
+      cancelAnimationFrame(animationFrameRef.current);
+      animationFrameRef.current = null;
+    }
+    setIsRunning(false);
+    setConvergedAtStep(null);
+    managerRef.current?.dispose();
+
+    const config: NSimConfig = {
+      size,
+      temperature,
+      weights: { ...weights },
+      instances: instances.map((i) => ({ ...i })),
+    };
+    const manager = new NSimulationManager(config);
+    managerRef.current = manager;
+
+    setControllers(manager.getControllers());
+    setActiveInstances(manager.getInstanceConfigs());
+    setIsLargeActive(manager.isLarge());
+    setSpread(manager.getRelativeSpread());
+    setSnapshots(manager.getSnapshots().map((s) => s.stats));
+  }, [size, temperature, weights, instances]);
+
+  // Build on mount and dispose on unmount (terminating workers).
+  useEffect(() => {
+    applyConfig();
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+      }
+      managerRef.current?.dispose();
+      managerRef.current = null;
+    };
+    // Only build once on mount; Apply triggers explicit rebuilds.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // The rAF tick: for small lattices it drives stepsPerFrame steps; for large
+  // lattices the workers self-drive (run() already started them), so the tick
+  // only samples history + readouts and evaluates the stop condition.
+  const tick = useCallback(() => {
+    const manager = managerRef.current;
+    if (!manager || !isRunningRef.current) return;
+
+    if (!manager.isLarge()) {
+      for (let i = 0; i < stepsPerFrame; i++) {
+        manager.step();
+      }
+    }
+
+    manager.pushHistory();
+    refreshReadouts();
+
+    if (manager.evaluateStop(stopPredicateRef.current)) {
+      setConvergedAtStep(manager.getStep());
+      setIsRunning(false);
+      manager.pause();
+      return;
+    }
+
+    animationFrameRef.current = requestAnimationFrame(tick);
+  }, [stepsPerFrame, refreshReadouts]);
+
+  // Start/stop the run loop.
+  useEffect(() => {
+    const manager = managerRef.current;
+    if (!manager) return;
+    if (isRunning) {
+      setConvergedAtStep(null);
+      if (manager.isLarge()) {
+        manager.run();
+      }
+      animationFrameRef.current = requestAnimationFrame(tick);
+    } else {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+      manager.pause();
+    }
+    return () => {
+      if (animationFrameRef.current) {
+        cancelAnimationFrame(animationFrameRef.current);
+        animationFrameRef.current = null;
+      }
+    };
+  }, [isRunning, tick]);
+
+  const handleReset = useCallback(() => {
+    setIsRunning(false);
+    setConvergedAtStep(null);
+    managerRef.current?.reset();
+    refreshReadouts();
+  }, [refreshReadouts]);
+
+  // Live weight updates apply to the running controllers too.
+  const handleWeightChange = useCallback((type: keyof NSimWeights, value: number) => {
+    setWeights((prev) => {
+      const next = { ...prev, [type]: value };
+      managerRef.current?.getControllers().forEach((c) => c.updateParams({ weights: { ...next } }));
+      return next;
+    });
+  }, []);
+
+  const addInstance = useCallback(() => {
+    setInstances((prev) => {
+      if (prev.length >= MAX_INSTANCES) return prev;
+      return [...prev, makeInstance('random', `Sim ${prev.length + 1} · Random`)];
+    });
+  }, []);
+
+  const removeInstance = useCallback((id: string) => {
+    setInstances((prev) => (prev.length <= 1 ? prev : prev.filter((i) => i.id !== id)));
+  }, []);
+
+  const updateInstance = useCallback((id: string, patch: Partial<NSimInstanceConfig>) => {
+    setInstances((prev) => prev.map((i) => (i.id === id ? { ...i, ...patch } : i)));
+  }, []);
+
+  const renderConfig: Partial<RenderConfig> = useMemo(
+    () => ({
+      mode: RenderMode.Paths,
+      showGrid: true,
+      animateFlips: false,
+      cellSize: 30,
+      lineWidth: 2,
+      colors: getThemeColors(isDarkMode),
+    }),
+    [isDarkMode],
+  );
+
+  const converged = convergedAtStep !== null;
+  const observables = snapshots.map((s) =>
+    typeof s.height === 'number' ? s.height : s.vertexCounts.c2,
+  );
+
+  return (
+    <PageShell
+      title="N-Simulation Comparison"
+      subtitle="Run any number of 6-vertex simulations from mixed initial conditions and stop automatically when they converge."
+    >
+      <div className={styles.page}>
+        <div className={styles.panel}>
+          <div className={styles.controlsGrid}>
+            <div className="control-group">
+              <label>
+                Lattice Size: {size}×{size}
+                <input
+                  type="range"
+                  min="4"
+                  max="256"
+                  value={size}
+                  onChange={(e) => setSize(Number(e.target.value))}
+                  disabled={isRunning}
+                />
+              </label>
+            </div>
+
+            <div className="control-group">
+              <label>
+                Temperature: {temperature.toFixed(2)}
+                <input
+                  type="range"
+                  min="0.1"
+                  max="2"
+                  step="0.1"
+                  value={temperature}
+                  onChange={(e) => setTemperature(Number(e.target.value))}
+                  disabled={isRunning}
+                />
+              </label>
+            </div>
+
+            <div className="control-group">
+              <label>
+                Speed: {stepsPerFrame} steps/frame
+                <input
+                  type="range"
+                  min="1"
+                  max="200"
+                  step="1"
+                  value={stepsPerFrame}
+                  onChange={(e) => setStepsPerFrame(Number(e.target.value))}
+                />
+              </label>
+            </div>
+          </div>
+
+          <div className={styles.weightsSection}>
+            <h3>Vertex Weights</h3>
+            <div className={styles.weightsGrid}>
+              {(Object.entries(weights) as [keyof NSimWeights, number][]).map(([type, value]) => (
+                <label key={type}>
+                  {type.toUpperCase()}: {value.toFixed(1)}
+                  <input
+                    type="range"
+                    min="0.1"
+                    max="2"
+                    step="0.1"
+                    value={value}
+                    onChange={(e) => handleWeightChange(type, Number(e.target.value))}
+                  />
+                </label>
+              ))}
+            </div>
+          </div>
+
+          <div className={styles.instancesSection}>
+            <h3>Simulations ({instances.length})</h3>
+            {instances.map((instance, idx) => (
+              <div key={instance.id} className={styles.instanceRow}>
+                <input
+                  type="text"
+                  value={instance.label}
+                  aria-label={`${labelPrefix}-label-${idx}`}
+                  onChange={(e) => updateInstance(instance.id, { label: e.target.value })}
+                  disabled={isRunning}
+                />
+                <select
+                  value={instance.initialState}
+                  aria-label={`Initial state for ${instance.label}`}
+                  onChange={(e) =>
+                    updateInstance(instance.id, {
+                      initialState: e.target.value as NSimInitialState,
+                    })
+                  }
+                  disabled={isRunning}
+                >
+                  <option value="dwbc-high">DWBC High</option>
+                  <option value="dwbc-low">DWBC Low</option>
+                  <option value="random">Random</option>
+                </select>
+                <input
+                  type="number"
+                  value={instance.seed}
+                  aria-label={`Seed for ${instance.label}`}
+                  onChange={(e) => updateInstance(instance.id, { seed: Number(e.target.value) })}
+                  disabled={isRunning}
+                  style={{ width: '6rem' }}
+                />
+                <button
+                  type="button"
+                  className="btn btn--secondary"
+                  onClick={() => removeInstance(instance.id)}
+                  disabled={isRunning || instances.length <= 1}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+            <button
+              type="button"
+              className="btn btn--secondary"
+              onClick={addInstance}
+              disabled={isRunning || instances.length >= MAX_INSTANCES}
+            >
+              Add simulation
+            </button>
+          </div>
+
+          <div className={styles.instancesSection}>
+            <h3>Stop Condition</h3>
+            <div className={styles.controlsGrid}>
+              <div className="control-group">
+                <label>
+                  Condition
+                  <select
+                    value={stopMode}
+                    onChange={(e) => setStopMode(e.target.value as StopMode)}
+                    disabled={isRunning}
+                  >
+                    <option value="all-converged">All converged</option>
+                    <option value="max-steps">Max steps</option>
+                    <option value="manual">Manual</option>
+                  </select>
+                </label>
+              </div>
+              {stopMode === 'max-steps' && (
+                <div className="control-group">
+                  <label>
+                    Max steps
+                    <input
+                      type="number"
+                      min="1"
+                      value={maxStepsValue}
+                      onChange={(e) => setMaxStepsValue(Number(e.target.value))}
+                      disabled={isRunning}
+                    />
+                  </label>
+                </div>
+              )}
+              {stopMode === 'all-converged' && (
+                <div className="control-group">
+                  <label>
+                    Threshold: {(convergenceThreshold * 100).toFixed(0)}%
+                    <input
+                      type="range"
+                      min="0.01"
+                      max="0.25"
+                      step="0.01"
+                      value={convergenceThreshold}
+                      onChange={(e) => setConvergenceThreshold(Number(e.target.value))}
+                      disabled={isRunning}
+                    />
+                  </label>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.actionButtons}>
+            <button
+              type="button"
+              onClick={() => setIsRunning((r) => !r)}
+              className={`btn ${isRunning ? 'btn--danger' : 'btn--success'}`}
+            >
+              {isRunning ? 'Pause' : 'Run'}
+            </button>
+            <button type="button" onClick={handleReset} className="btn btn--primary">
+              Reset
+            </button>
+            <button
+              type="button"
+              onClick={applyConfig}
+              disabled={isRunning}
+              className="btn btn--secondary"
+            >
+              Apply
+            </button>
+            {converged && <span className={styles.badge}>Converged at step {convergedAtStep}</span>}
+          </div>
+        </div>
+
+        <div className={styles.convergencePanel}>
+          <div>
+            <div className={styles.metricLabel}>Relative spread</div>
+            <div className={styles.metricValue}>{(spread * 100).toFixed(2)}%</div>
+          </div>
+          <div>
+            <div className={styles.metricLabel}>Instances</div>
+            <div className={styles.metricValue}>{activeInstances.length}</div>
+          </div>
+          <div>
+            <div className={styles.metricLabel}>Status</div>
+            <div className={`${styles.statusValue} ${converged ? styles.statusConverged : ''}`}>
+              {converged ? 'Converged ✓' : isRunning ? 'Running…' : 'Idle'}
+            </div>
+          </div>
+        </div>
+
+        <div className={styles.grid}>
+          {controllers.map((controller, idx) => (
+            <InstancePanel
+              key={activeInstances[idx]?.id ?? idx}
+              controller={controller}
+              label={activeInstances[idx]?.label ?? `Sim ${idx + 1}`}
+              initialState={activeInstances[idx]?.initialState ?? 'random'}
+              seed={activeInstances[idx]?.seed ?? 0}
+              isLarge={isLargeActive}
+              renderConfig={renderConfig}
+              observable={observables[idx] ?? 0}
+            />
+          ))}
+        </div>
+
+        <div className={styles.panel}>
+          <h3>About N-Simulation Comparison</h3>
+          <p>
+            This page runs several 6-vertex Monte Carlo simulations in parallel. They share the same
+            lattice size, temperature and vertex weights but start from different initial conditions
+            (DWBC High, DWBC Low, or Random) and different random seeds. The system tracks a coarse
+            macroscopic observable (the height function, falling back to the c<sub>2</sub> count)
+            for each simulation and reports the relative spread across all of them.
+          </p>
+          <ul>
+            <li>
+              <strong>All converged</strong>: stops once the relative spread stays at or below the
+              threshold for a full window of recent samples, with at least two simulations.
+            </li>
+            <li>
+              <strong>Max steps</strong>: stops once the leading simulation reaches the chosen step
+              count.
+            </li>
+            <li>
+              <strong>Manual</strong>: runs until you press Pause.
+            </li>
+          </ul>
+          <p>
+            Lattices larger than {LARGE_LATTICE_THRESHOLD} render via the fast bitmap path and run
+            inside Web Workers, one per simulation.
+          </p>
+        </div>
+      </div>
+    </PageShell>
+  );
+}
+
+export default NSimulation;

--- a/client/tests/six-vertex/stopConditions.test.ts
+++ b/client/tests/six-vertex/stopConditions.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  allConverged,
+  combineStop,
+  divergenceExceeded,
+  heightObservable,
+  manual,
+  maxSteps,
+  relativeSpread,
+  type NSimSnapshot,
+  type StopContext,
+} from '../../src/lib/six-vertex/stopConditions';
+import { VertexType, type SimulationStats } from '../../src/lib/six-vertex/types';
+
+function makeStats(overrides: Partial<SimulationStats> = {}): SimulationStats {
+  return {
+    step: 0,
+    energy: 0,
+    vertexCounts: {
+      [VertexType.a1]: 0,
+      [VertexType.a2]: 0,
+      [VertexType.b1]: 0,
+      [VertexType.b2]: 0,
+      [VertexType.c1]: 0,
+      [VertexType.c2]: 0,
+    },
+    acceptanceRate: 0,
+    flipAttempts: 0,
+    successfulFlips: 0,
+    beta: 1,
+    ...overrides,
+  };
+}
+
+function snapshot(observable: number, step = 0): NSimSnapshot {
+  return { step, observable, stats: makeStats({ step }) };
+}
+
+/** Build a StopContext whose per-instance history is a constant value repeated. */
+function ctxFromConstantHistories(values: number[], samples: number, step = 1000): StopContext {
+  const history = values.map((v) => Array(samples).fill(v));
+  const instances = values.map((v) => snapshot(v, step));
+  return { step, instances, history };
+}
+
+describe('relativeSpread', () => {
+  it('is 0 for identical values', () => {
+    expect(relativeSpread([5, 5, 5])).toBe(0);
+  });
+
+  it('is scale-free: (max-min)/mean', () => {
+    // [9, 11] -> spread 2, mean 10 -> 0.2
+    expect(relativeSpread([9, 11])).toBeCloseTo(0.2, 10);
+  });
+
+  it('returns 0 for an empty set', () => {
+    expect(relativeSpread([])).toBe(0);
+  });
+});
+
+describe('heightObservable', () => {
+  it('prefers stats.height when present', () => {
+    expect(heightObservable(makeStats({ height: 42 }))).toBe(42);
+  });
+
+  it('falls back to the c2 vertex count', () => {
+    const stats = makeStats();
+    stats.vertexCounts[VertexType.c2] = 7;
+    expect(heightObservable(stats)).toBe(7);
+  });
+});
+
+describe('maxSteps', () => {
+  it('does not fire below the threshold', () => {
+    const { predicate } = maxSteps(100);
+    expect(predicate({ step: 99, instances: [], history: [] })).toBe(false);
+  });
+
+  it('fires exactly at the threshold (boundary)', () => {
+    const { predicate } = maxSteps(100);
+    expect(predicate({ step: 100, instances: [], history: [] })).toBe(true);
+  });
+
+  it('fires above the threshold', () => {
+    const { predicate } = maxSteps(100);
+    expect(predicate({ step: 101, instances: [], history: [] })).toBe(true);
+  });
+});
+
+describe('allConverged', () => {
+  it('fires when histories are tight across the full window', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 30 });
+    // Two instances within 1% of each other for 30 samples.
+    const ctx = ctxFromConstantHistories([100, 100.5], 30);
+    expect(predicate(ctx)).toBe(true);
+  });
+
+  it('does not fire before the window has filled', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 30 });
+    const ctx = ctxFromConstantHistories([100, 100], 29); // tight but only 29 samples
+    expect(predicate(ctx)).toBe(false);
+  });
+
+  it('does not fire when convergence is only brief (last sample tight, earlier wide)', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 3 });
+    // window of 3: samples [wide, wide, tight] -> must not stop.
+    const history = [
+      [100, 100, 100],
+      [200, 150, 100.5],
+    ];
+    const instances = [snapshot(100), snapshot(100.5)];
+    expect(predicate({ step: 999, instances, history })).toBe(false);
+  });
+
+  it('fires when the last window is tight even if older samples were wide', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 2 });
+    const history = [
+      [500, 100, 100], // last 2: 100,100
+      [100, 100, 100.5], // last 2: 100,100.5
+    ];
+    const instances = [snapshot(100), snapshot(100.5)];
+    expect(predicate({ step: 999, instances, history })).toBe(true);
+  });
+
+  it('returns false with fewer than 2 instances (cannot converge alone)', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 5 });
+    const ctx = ctxFromConstantHistories([100], 50);
+    expect(predicate(ctx)).toBe(false);
+  });
+
+  it('does not fire when instances stay far apart', () => {
+    const { predicate } = allConverged({ threshold: 0.05, window: 10 });
+    const ctx = ctxFromConstantHistories([100, 200], 30);
+    expect(predicate(ctx)).toBe(false);
+  });
+});
+
+describe('divergenceExceeded', () => {
+  it('fires when current relative spread meets the threshold', () => {
+    const { predicate } = divergenceExceeded({ threshold: 0.2 });
+    // [80, 120] -> spread 40, mean 100 -> 0.4 >= 0.2
+    const instances = [snapshot(80), snapshot(120)];
+    expect(predicate({ step: 10, instances, history: [] })).toBe(true);
+  });
+
+  it('does not fire when instances are close', () => {
+    const { predicate } = divergenceExceeded({ threshold: 0.5 });
+    const instances = [snapshot(100), snapshot(101)];
+    expect(predicate({ step: 10, instances, history: [] })).toBe(false);
+  });
+
+  it('returns false with fewer than 2 instances', () => {
+    const { predicate } = divergenceExceeded({ threshold: 0.01 });
+    expect(predicate({ step: 10, instances: [snapshot(100)], history: [] })).toBe(false);
+  });
+});
+
+describe('manual', () => {
+  it('never fires', () => {
+    const { predicate } = manual();
+    expect(predicate(ctxFromConstantHistories([100, 100], 1000))).toBe(false);
+  });
+});
+
+describe('combineStop', () => {
+  const yes = () => true;
+  const no = () => false;
+  const empty: StopContext = { step: 0, instances: [], history: [] };
+
+  it('any: fires if at least one predicate fires', () => {
+    expect(combineStop([no, yes, no], 'any')(empty)).toBe(true);
+    expect(combineStop([no, no], 'any')(empty)).toBe(false);
+  });
+
+  it('all: fires only when every predicate fires', () => {
+    expect(combineStop([yes, yes], 'all')(empty)).toBe(true);
+    expect(combineStop([yes, no], 'all')(empty)).toBe(false);
+  });
+
+  it('empty predicate list never stops', () => {
+    expect(combineStop([], 'any')(empty)).toBe(false);
+    expect(combineStop([], 'all')(empty)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-67.dev.6v.allison.la

## Summary
New **/n-simulation** page ("Compare N Sims") that runs **1..6** 6-vertex Monte Carlo simulations together from **mixed initial conditions** (DWBC High / Low / Random) with per-instance seeds and shared size/temperature/weights, and **composable stop conditions** that auto-stop the run when the simulations converge. This is the unified core for which single (N=1) and dual (N=2) are special cases. Part of EPIC #54.

## Changes
- **`stopConditions.ts` (new)** — pure, composable stop predicates over a `StopContext`: `maxSteps`, `allConverged` (cross-instance relative spread ≤ threshold sustained over a window; requires ≥2 instances + a full window before firing), `divergenceExceeded`, `manual`, and `combineStop(any/all)`. `heightObservable()` uses `stats.height` (else the c₂ count) as a coarse macroscopic proxy; `relativeSpread()` is scale-free. **21 unit tests** over synthetic contexts.
- **`nSimulation.ts` (new)** — `NSimulationManager` orchestrates one **worker-capable** `SimulationController` per instance, tracks per-instance observable history, exposes `getControllers()` for the route to subscribe, evaluates stop predicates, and `dispose()`s every controller (terminating workers) so nothing leaks across rebuilds.
- **`routes/nSimulation.tsx` (new)** — the page: add/remove instances, per-instance init-state + seed pickers, shared controls, stop-condition selector, live relative-spread readout + "Converged at step N" badge, responsive canvas grid. Each `InstancePanel` owns a **stable** `PathRenderer` (refs, not per-frame closures) and is **large-aware** (raw bitmap path for N>128) — mirroring MainSimulator. A single rAF tick drives small lattices; large lattices self-drive in workers and the tick samples history + evaluates the stop condition. Manager disposed on unmount and before each Apply rebuild.
- **`App.tsx`** — register the route + nav link in the Learn group.

Existing single + dual routes are **intentionally untouched** (no regression); re-backing the dual route on this core is a documented follow-up.

## Testing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean
- [x] `npx jest --ci` — **338/338** (+21 new stop-condition tests)
- [x] `npm run build` passes
- [x] **In-browser**: N=2 High/Low animate independently with a live relative-spread readout; **max-steps stop fires** and auto-stops ("Converged at step 1507"); **N=3 mixed at 200×200** runs three workers concurrently with the UI at ~**60fps** (19ms frames); add/remove clamps 1..6; Reset/Apply rebuild without leaking workers
- [ ] Preview deployment tested

## Related Issues
Refs #58 (EPIC #54)

## Checklist
- [x] Code follows project conventions
- [x] Tests added (21)
- [x] Ice rule / reproducibility preserved (per-instance seeded engines)
- [x] No regression to single/dual routes
- [x] CI checks pass
- [x] Preview link included
