### PR TITLE
fix: FastRNG returned [0,~2.0) not [0,1) — corrupted MC dynamics (#68)

### DIFF
--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -64,7 +64,11 @@ class FastRNG {
 
     this.state[0] = t ^ s ^ (s >>> 19);
 
-    return (this.state[0] + this.state[1]) / 4294967296;
+    // Mask the sum back to uint32 before normalizing. Without `>>> 0` the sum of
+    // two uint32 words reaches ~2^33, so this returned values in [0, ~2.0) — half
+    // of all draws were >= 1.0, which silently biased every acceptance test and
+    // made nextInt() return out-of-bounds indices. Now strictly in [0, 1).
+    return ((this.state[0] + this.state[1]) >>> 0) / 4294967296;
   }
 
   nextInt(max: number): number {

--- a/client/tests/six-vertex/optimizedEngine.test.ts
+++ b/client/tests/six-vertex/optimizedEngine.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from '@jest/globals';
+// Drive the SHIPPING engine directly (OptimizedPhysicsSimulation / FastRNG).
+// The older heatBath/equilibrium/reproducibility suites exercise a different,
+// non-shipping code path (physicsSimulation + SeededRNG), so they never caught
+// the FastRNG range bug (#68). These tests cover the real engine.
+import { OptimizedPhysicsSimulation } from '../../src/lib/six-vertex/optimizedSimulation';
+
+const EQUAL = { a1: 1, a2: 1, b1: 1, b2: 1, c1: 1, c2: 1 };
+const C_DOMINANT = { a1: 1, a2: 1, b1: 1, b2: 1, c1: 5, c2: 5 };
+const A_DOMINANT = { a1: 5, a2: 5, b1: 1, b2: 1, c1: 1, c2: 1 };
+
+// The engine's RNG is private; exercise it indirectly through nextInt-driven
+// behavior by asserting the engine never produces out-of-range vertex types and
+// makes progress. For a direct range check we reach the private rng via a cast —
+// this is a white-box regression guard for the #68 fix.
+describe('FastRNG range (#68 regression)', () => {
+  it('next() stays in [0, 1) and nextInt(max) in [0, max) over many draws', () => {
+    const sim = new OptimizedPhysicsSimulation({ size: 8, weights: EQUAL, seed: 42 });
+    // Access the private FastRNG instance for a direct distribution check.
+    const rng = (sim as unknown as { rng: { next(): number; nextInt(n: number): number } }).rng;
+    let maxV = 0;
+    let geOne = 0;
+    let oob = 0;
+    const N = 200000;
+    for (let i = 0; i < N; i++) {
+      const v = rng.next();
+      if (v > maxV) maxV = v;
+      if (v >= 1) geOne++;
+      const k = rng.nextInt(10);
+      if (k < 0 || k >= 10) oob++;
+    }
+    expect(geOne).toBe(0);
+    expect(maxV).toBeLessThan(1);
+    expect(maxV).toBeGreaterThan(0.9); // still spans the range
+    expect(oob).toBe(0);
+  });
+});
+
+describe('OptimizedPhysicsSimulation evolves (no freeze)', () => {
+  it('accepts flips and changes configuration at the ice point', () => {
+    const sim = new OptimizedPhysicsSimulation({ size: 24, weights: EQUAL, seed: 7 });
+    const before = sim.getRawState();
+    sim.run(20000);
+    const stats = sim.getStats();
+    const after = sim.getRawState();
+    expect(stats.successfulFlips).toBeGreaterThan(0);
+    expect(stats.acceptanceRate).toBeGreaterThan(0);
+    let changed = 0;
+    for (let i = 0; i < before.length; i++) if (before[i] !== after[i]) changed++;
+    expect(changed).toBeGreaterThan(0);
+  });
+
+  it('does NOT freeze under c-dominant weights (the #68 symptom)', () => {
+    const sim = new OptimizedPhysicsSimulation({
+      size: 16,
+      weights: C_DOMINANT,
+      seed: 7,
+      initialState: 'dwbc-high',
+    });
+    sim.run(20000);
+    const stats = sim.getStats();
+    // Before the fix this froze: 0 successful flips, acceptanceRate 0.
+    expect(stats.successfulFlips).toBeGreaterThan(0);
+    expect(stats.acceptanceRate).toBeGreaterThan(0);
+  });
+
+  it('evolves under a-dominant weights too', () => {
+    const sim = new OptimizedPhysicsSimulation({
+      size: 16,
+      weights: A_DOMINANT,
+      seed: 11,
+      initialState: 'dwbc-low',
+    });
+    sim.run(20000);
+    expect(sim.getStats().successfulFlips).toBeGreaterThan(0);
+  });
+});
+
+describe('reproducibility of the shipping engine', () => {
+  it('same seed -> identical trajectory', () => {
+    const a = new OptimizedPhysicsSimulation({ size: 32, weights: EQUAL, seed: 12345 });
+    const b = new OptimizedPhysicsSimulation({ size: 32, weights: EQUAL, seed: 12345 });
+    a.run(5000);
+    b.run(5000);
+    const ra = a.getRawState();
+    const rb = b.getRawState();
+    expect(ra.length).toBe(rb.length);
+    let diff = 0;
+    for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) diff++;
+    expect(diff).toBe(0);
+  });
+
+  it('different seeds -> different trajectories', () => {
+    const a = new OptimizedPhysicsSimulation({ size: 32, weights: EQUAL, seed: 1 });
+    const b = new OptimizedPhysicsSimulation({ size: 32, weights: EQUAL, seed: 2 });
+    a.run(5000);
+    b.run(5000);
+    const ra = a.getRawState();
+    const rb = b.getRawState();
+    let diff = 0;
+    for (let i = 0; i < ra.length; i++) if (ra[i] !== rb[i]) diff++;
+    expect(diff).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-70.dev.6v.allison.la

## Summary
Critical physics fix found by the #63 adversarial audit. \`FastRNG.next()\` returned \`(state[0] + state[1]) / 2³²\`; both state words are uint32 so the sum reached ~2³³ and the result ranged over **[0, ~2.0)** — **49.85%** of draws were ≥ 1.0 (measured, max 1.9975).

## Impact
- \`nextInt(max) = (next()*max)|0\` returned **out-of-bounds indices ~50%** of the time → Monte Carlo site selection picked invalid flippable entries half the time.
- Acceptance tests \`next() < prob\` spuriously rejected ~half the time for any prob ≤ 1.
- Under **c-dominant weights the chain froze** (0 accepted flips) — the Ferroelectric / c-favoring presets never evolved.

## Fix
Mask the sum to uint32 before normalizing: \`((state[0] + state[1]) >>> 0) / 2³²\` → strict **[0, 1)**. Determinism unchanged (fixed seed → fixed stream); only the wrong distribution is corrected.

## Tests
Adds \`tests/six-vertex/optimizedEngine.test.ts\` driving the **shipping** engine directly (the older heatBath/equilibrium/reproducibility suites exercise a different non-shipping path and never caught this — see #69):
- \`next()\` ∈ [0,1) and \`nextInt(max)\` ∈ [0,max) over 200k draws
- engine evolves at the ice point; **does NOT freeze** under c-dominant or a-dominant weights
- same-seed → identical trajectory; different seeds → different trajectories

## Verification
- [x] Empirically confirmed the bug (49.85% ≥1.0) and the fix (0% ≥1.0)
- [x] \`tsc\` clean, \`eslint\` clean (pre-existing \`any\` warnings only), \`jest\` **344/344** (+6), \`build\` OK
- [ ] Preview deployment tested

## Related
Fixes #68 · Refs #63 (audit) · remaining audit findings tracked in #69

## Checklist
- [x] Code follows project conventions
- [x] Tests added (real engine coverage)
- [x] Ice rule / reproducibility preserved
- [x] CI checks pass
- [x] Preview link included
