### PR TITLE
fix: correct MC acceptance rule — favoring a vertex type now increases it (#69)

### DIFF
--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -128,7 +128,6 @@ export class OptimizedPhysicsSimulation {
   private successfulFlips: number = 0;
   private attemptedFlips: number = 0;
   private currentHeight: number = 0;
-  private rho: number;
 
   // Performance options
   private batchSize: number;
@@ -149,9 +148,6 @@ export class OptimizedPhysicsSimulation {
     this.weights[VERTEX_B2] = config.weights.b2;
     this.weights[VERTEX_C1] = config.weights.c1;
     this.weights[VERTEX_C2] = config.weights.c2;
-
-    // Calculate rho
-    this.rho = this.calculateRho();
 
     // Initialize state
     this.initializeState(config.initialState || 'dwbc-high');
@@ -196,30 +192,6 @@ export class OptimizedPhysicsSimulation {
   public step(): any {
     this.performStep();
     return this.getStats();
-  }
-
-  /**
-   * Calculate optimal rho value
-   */
-  private calculateRho(): number {
-    let maxWeight = 0;
-
-    // Check all possible 2x2 configurations
-    for (let v1 = 0; v1 < 6; v1++) {
-      for (let v2 = 0; v2 < 6; v2++) {
-        for (let v3 = 0; v3 < 6; v3++) {
-          for (let v4 = 0; v4 < 6; v4++) {
-            const weight =
-              this.weights[v1] * this.weights[v2] * this.weights[v3] * this.weights[v4];
-            if (weight > maxWeight) {
-              maxWeight = weight;
-            }
-          }
-        }
-      }
-    }
-
-    return 1.0 / maxWeight;
   }
 
   /**
@@ -474,7 +446,13 @@ export class OptimizedPhysicsSimulation {
     if (pos.canFlipUp && !pos.canFlipDown) {
       // Can only flip up
       const weightRatio = this.getWeightRatio(pos.row, pos.col, FlipDirection.Up);
-      const acceptanceProbability = Math.min(1.0, this.rho * weightRatio);
+      // Heat-bath acceptance over {stay, flip}: p = w_after/(w_before+w_after) =
+      // ratio/(1+ratio). This matches the biflip branch below and samples the
+      // correct Gibbs measure. The old `min(1, ratio/maxWeight)` divided by the
+      // global max plaquette weight, collapsing acceptance to ~0 whenever any
+      // weight was favored — it froze c-/a-dominant runs and inverted the
+      // equilibrium (favoring a vertex type produced FEWER of it). See #69.
+      const acceptanceProbability = weightRatio / (1.0 + weightRatio);
 
       if (this.rng.next() < acceptanceProbability) {
         if (this.executeFlipInPlace(pos.row, pos.col, FlipDirection.Up)) {
@@ -485,7 +463,8 @@ export class OptimizedPhysicsSimulation {
     } else if (!pos.canFlipUp && pos.canFlipDown) {
       // Can only flip down
       const weightRatio = this.getWeightRatio(pos.row, pos.col, FlipDirection.Down);
-      const acceptanceProbability = Math.min(1.0, this.rho * weightRatio);
+      // Heat-bath acceptance over {stay, flip}; see the Up branch above (#69).
+      const acceptanceProbability = weightRatio / (1.0 + weightRatio);
 
       if (this.rng.next() < acceptanceProbability) {
         if (this.executeFlipInPlace(pos.row, pos.col, FlipDirection.Down)) {

--- a/client/tests/six-vertex/optimizedEngine.test.ts
+++ b/client/tests/six-vertex/optimizedEngine.test.ts
@@ -102,3 +102,43 @@ describe('reproducibility of the shipping engine', () => {
     expect(diff).toBeGreaterThan(0);
   });
 });
+
+describe('equilibrium responds correctly to weights (#69 acceptance rule)', () => {
+  // A correct sampler MUST increase a vertex type's equilibrium fraction when its
+  // weight is favored. The old acceptance rule (min(1, ratio/maxWeight)) did the
+  // opposite: favoring c/a produced FEWER of them and froze (acceptance ~0).
+  const cFraction = (sim: OptimizedPhysicsSimulation) => {
+    const v = sim.getStats().vertexCounts;
+    const t = v.a1 + v.a2 + v.b1 + v.b2 + v.c1 + v.c2;
+    return (v.c1 + v.c2) / t;
+  };
+  const aFraction = (sim: OptimizedPhysicsSimulation) => {
+    const v = sim.getStats().vertexCounts;
+    const t = v.a1 + v.a2 + v.b1 + v.b2 + v.c1 + v.c2;
+    return (v.a1 + v.a2) / t;
+  };
+  const run = (weights: typeof EQUAL, seed = 7) => {
+    const sim = new OptimizedPhysicsSimulation({
+      size: 32,
+      weights,
+      seed,
+      initialState: 'dwbc-high',
+    });
+    sim.run(300000);
+    return sim;
+  };
+
+  it('favoring c-vertices increases the c fraction (and keeps acceptance > 0)', () => {
+    const ice = run(EQUAL);
+    const cdom = run(C_DOMINANT);
+    expect(cFraction(cdom)).toBeGreaterThan(cFraction(ice));
+    expect(cdom.getStats().acceptanceRate).toBeGreaterThan(0);
+  });
+
+  it('favoring a-vertices increases the a fraction (and keeps acceptance > 0)', () => {
+    const ice = run(EQUAL);
+    const adom = run(A_DOMINANT);
+    expect(aFraction(adom)).toBeGreaterThan(aFraction(ice));
+    expect(adom.getStats().acceptanceRate).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-71.dev.6v.allison.la

## Summary
Core physics-correctness fix found by the #63 adversarial audit (finding C2), surfaced after the #68 RNG fix. The single-direction flip acceptance was \`min(1, rho · weightRatio)\` with \`rho = 1/maxWeight\` (max 2×2 plaquette weight over **all** configs, e.g. 5⁴=625 for c-dominant). That global \`1/maxWeight\` factor crushed acceptance to ~0 whenever any vertex weight was favored, which **froze c-/a-dominant runs and inverted the equilibrium** — favoring a vertex type produced *fewer* of it.

## Evidence (N=32, 300k steps from DWBC-high)
| weights | before (buggy) | after (fixed) | ice point |
|---|---|---|---|
| c-dominant (c×5) | c-frac **0.09**, accept **0.000** | c-frac **0.389**, accept 0.071 | c-frac 0.238 |
| a-dominant (a×5) | a-frac **0.09**, accept **0.001** | a-frac **0.594**, accept 0.138 | a-frac 0.326 |

Before, favoring c/a gave *less* c/a than the unbiased ice point (backwards) and froze. After, favoring a type **increases** its fraction, as physically required; the ice point is essentially unchanged.

## Fix
Use heat-bath acceptance over {stay, flip}: \`p = w_after/(w_before + w_after) = ratio/(1+ratio)\`. This matches the biflip branch (already heat-bath) and samples the correct Gibbs measure ∝ ∏ wᵢⁿⁱ. Removed the bogus \`rho\`/\`calculateRho\`.

## Tests
Adds monotonicity regressions to \`optimizedEngine.test.ts\`: favoring c-vertices raises the c-fraction above the ice point (same for a), with acceptance > 0.

## Verification
- [x] Empirically confirmed inversion before and correct response after
- [x] \`tsc\` clean, \`eslint\` clean, \`jest\` **346/346**, \`build\` OK
- [ ] Preview deployment tested

## Related
Refs #69 (audit findings) · #63 (audit) · follows #68 (RNG)

## Checklist
- [x] Code follows project conventions
- [x] Tests added (equilibrium monotonicity)
- [x] Detailed balance preserved (heat-bath samples correct Gibbs measure)
- [x] CI checks pass
- [x] Preview link included
