### PR TITLE
fix: paper-style renderer ignored theme colors — paths invisible in dark mode (#69)

### DIFF
--- a/client/src/lib/six-vertex/renderer/continuousPathRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/continuousPathRenderer.ts
@@ -4,7 +4,7 @@
  */
 
 import type { LatticeState } from '../types';
-import { renderPaperStyle } from './paperStyleRenderer';
+import { renderPaperStyle, type PaperStyleColors } from './paperStyleRenderer';
 
 /**
  * Render continuous paths through the lattice (paper style)
@@ -13,9 +13,10 @@ export function renderContinuousPaths(
   ctx: CanvasRenderingContext2D,
   state: LatticeState,
   cellSize: number,
+  colors?: PaperStyleColors,
 ): void {
   // Use the new paper-style renderer
-  renderPaperStyle(ctx, state, cellSize);
+  renderPaperStyle(ctx, state, cellSize, colors);
 }
 
 /**

--- a/client/src/lib/six-vertex/renderer/paperStyleRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/paperStyleRenderer.ts
@@ -10,23 +10,42 @@ import { VertexType } from '../types';
  * Render in the exact style of the paper's Figures 2 and 3
  * Bold lines connect edges where arrows create continuous flow
  */
+/** Theme-aware colors for the paper-style renderer (all optional; sensible
+ * light-mode defaults are used when omitted). Without these the renderer drew
+ * hardcoded black strokes on a transparent canvas, making paths invisible in
+ * dark mode (see #69). */
+export interface PaperStyleColors {
+  background?: string;
+  grid?: string;
+  pathSegment?: string;
+}
+
 export function renderPaperStyle(
   ctx: CanvasRenderingContext2D,
   state: LatticeState,
   cellSize: number,
+  colors?: PaperStyleColors,
 ): void {
-  // Clear canvas
+  const pathColor = colors?.pathSegment ?? '#000000';
+  const gridColor = colors?.grid ?? '#d0d0d0';
+
+  // Clear, then paint the themed background (transparent would leave paths
+  // unreadable on a dark page).
   ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  if (colors?.background) {
+    ctx.fillStyle = colors.background;
+    ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  }
 
   // Set up drawing style for bold paths
-  ctx.strokeStyle = '#000000';
+  ctx.strokeStyle = pathColor;
   ctx.lineWidth = cellSize / 8;
   ctx.lineCap = 'square';
   ctx.lineJoin = 'miter';
 
   // Draw grid first (thin lines)
   ctx.save();
-  ctx.strokeStyle = '#d0d0d0';
+  ctx.strokeStyle = gridColor;
   ctx.lineWidth = 1;
 
   // Vertical grid lines
@@ -56,7 +75,7 @@ export function renderPaperStyle(
   // - c1: L-shape left-bottom
   // - c2: L-shape top-right
 
-  ctx.strokeStyle = '#000000';
+  ctx.strokeStyle = pathColor;
   ctx.lineWidth = cellSize / 8;
 
   for (let row = 0; row < state.height; row++) {

--- a/client/src/lib/six-vertex/renderer/pathRenderer.ts
+++ b/client/src/lib/six-vertex/renderer/pathRenderer.ts
@@ -184,8 +184,13 @@ export class PathRenderer {
    * Draw paths (bold edges) - Paper style with continuous paths
    */
   private drawPaths(state: LatticeState): void {
-    // Use the new continuous path renderer that matches the paper style
-    renderContinuousPaths(this.ctx, state, this.config.cellSize);
+    // Use the new continuous path renderer that matches the paper style.
+    // Pass theme colors so paths/grid/background are legible in dark mode (#69).
+    renderContinuousPaths(this.ctx, state, this.config.cellSize, {
+      background: this.config.colors?.background,
+      grid: this.config.colors?.grid,
+      pathSegment: this.config.colors?.pathSegment,
+    });
   }
 
   /**

--- a/client/tests/six-vertex/paperStyleColors.test.ts
+++ b/client/tests/six-vertex/paperStyleColors.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderPaperStyle } from '../../src/lib/six-vertex/renderer/paperStyleRenderer';
+import { getVertexConfiguration, VertexType } from '../../src/lib/six-vertex/types';
+import type { LatticeState, Vertex } from '../../src/lib/six-vertex/types';
+
+// Minimal recording 2D context — jsdom has no real canvas, and we only need to
+// observe which colors the renderer assigns. Records every strokeStyle/fillStyle
+// the renderer sets.
+function makeRecordingCtx() {
+  const strokeStyles: string[] = [];
+  const fillStyles: string[] = [];
+  let _stroke = '';
+  let _fill = '';
+  const ctx = {
+    canvas: { width: 200, height: 200 },
+    set strokeStyle(v: string) {
+      _stroke = v;
+      strokeStyles.push(v);
+    },
+    get strokeStyle() {
+      return _stroke;
+    },
+    set fillStyle(v: string) {
+      _fill = v;
+      fillStyles.push(v);
+    },
+    get fillStyle() {
+      return _fill;
+    },
+    lineWidth: 0,
+    lineCap: '',
+    lineJoin: '',
+    clearRect() {},
+    fillRect() {},
+    beginPath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    arc() {},
+    fill() {},
+    save() {},
+    restore() {},
+  };
+  return { ctx, strokeStyles, fillStyles };
+}
+
+function tinyLattice(): LatticeState {
+  const types = [VertexType.a1, VertexType.c2, VertexType.b1, VertexType.c1];
+  const vertices: Vertex[][] = [];
+  let i = 0;
+  for (let r = 0; r < 2; r++) {
+    const row: Vertex[] = [];
+    for (let c = 0; c < 2; c++) {
+      const type = types[i++ % types.length];
+      row.push({ position: { row: r, col: c }, type, configuration: getVertexConfiguration(type) });
+    }
+    vertices.push(row);
+  }
+  return { width: 2, height: 2, vertices, horizontalEdges: [], verticalEdges: [] };
+}
+
+describe('renderPaperStyle honors theme colors (#69 dark mode)', () => {
+  it('uses the supplied pathSegment, grid, and background colors', () => {
+    const { ctx, strokeStyles, fillStyles } = makeRecordingCtx();
+    renderPaperStyle(ctx as unknown as CanvasRenderingContext2D, tinyLattice(), 20, {
+      background: '#1a1a1a',
+      grid: '#404040',
+      pathSegment: '#e0e0e0',
+    });
+    // Bold paths must be drawn in the dark-mode path color, not hardcoded black.
+    expect(strokeStyles).toContain('#e0e0e0');
+    expect(strokeStyles).toContain('#404040');
+    expect(strokeStyles).not.toContain('#000000');
+    // Themed background must be painted (not left transparent).
+    expect(fillStyles).toContain('#1a1a1a');
+  });
+
+  it('falls back to light defaults when no colors are supplied', () => {
+    const { ctx, strokeStyles } = makeRecordingCtx();
+    renderPaperStyle(ctx as unknown as CanvasRenderingContext2D, tinyLattice(), 20);
+    expect(strokeStyles).toContain('#000000');
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-72.dev.6v.allison.la

## Summary
Dark-mode rendering bug found by the #63 audit. \`renderPaperStyle\` hardcoded \`#000000\` strokes and a \`#d0d0d0\` grid and never painted the themed background (only \`clearRect\`), so in dark mode the bold paths drew **black on a dark page — invisible**. Affects the main simulator, the dual page, and the new N-simulation page. The configured \`RenderConfig.colors\` (dark: pathSegment \`#e0e0e0\`, grid \`#404040\`, background \`#1a1a1a\`) were silently dropped.

## Fix
Thread an optional \`PaperStyleColors\` through \`renderContinuousPaths\` → \`renderPaperStyle\` (pathSegment / grid / background), defaulting to the previous light values when absent, and pass \`this.config.colors\` from \`PathRenderer.drawPaths\`. The renderer now paints the themed background and strokes paths/grid in the theme color.

## Tests
\`tests/six-vertex/paperStyleColors.test.ts\` (recording mock 2D context) asserts the renderer uses the supplied pathSegment/grid/background and falls back to light defaults when none are given.

## Verification
- [x] \`tsc\` clean, \`eslint\` clean, \`jest\` **348/348** (+2), \`build\` OK
- [x] **In-browser**: dark mode now shows light paths on a dark background with a visible grid (DWBC pattern legible)
- [ ] Preview deployment tested

## Related
Refs #69 (audit findings) · #63 (audit)

## Checklist
- [x] Code follows project conventions
- [x] Tests added (stroke-color coverage)
- [x] No logic/physics change (render-only)
- [x] CI checks pass
- [x] Preview link included
