### PR TITLE
fix: prevent worker thread + FPS rAF leaks (#69)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -92,12 +92,20 @@ function MainSimulator() {
     c2: 1.0,
   });
 
-  // FPS counter
+  // FPS counter. The rAF loop is owned by this effect and cancelled in cleanup;
+  // it must NOT self-gate on the `isRunning` closure (that value is captured at
+  // effect-run time and never updates), or the loop orphans itself and keeps
+  // scheduling forever after Pause — burning a frame's work every tick and
+  // leaking across every subsequent run.
   useEffect(() => {
+    if (!isRunning) {
+      setFps(0);
+      return;
+    }
+
     let frameCount = 0;
     let lastTime = performance.now();
-
-    const updateFps = () => {
+    let rafId = requestAnimationFrame(function tick() {
       const currentTime = performance.now();
       frameCount++;
 
@@ -107,14 +115,10 @@ function MainSimulator() {
         lastTime = currentTime;
       }
 
-      if (isRunning) {
-        requestAnimationFrame(updateFps);
-      }
-    };
+      rafId = requestAnimationFrame(tick);
+    });
 
-    if (isRunning) {
-      updateFps();
-    }
+    return () => cancelAnimationFrame(rafId);
   }, [isRunning]);
 
   // Initialize simulation

--- a/client/src/lib/six-vertex/simulation.ts
+++ b/client/src/lib/six-vertex/simulation.ts
@@ -79,6 +79,13 @@ export class MonteCarloSimulation implements SimulationController {
   // Set when run() is called before the (async) worker has finished initializing.
   // The worker starts its continuous loop as soon as it becomes ready.
   private pendingRun = false;
+  // Monotonic init token. Worker creation is async, so a second initialize() (or
+  // dispose()/reset()) can land while the first createWorkerSimulation() promise
+  // is still pending. Every initialize()/dispose() bumps this; the async
+  // resolution captures the token at call time and, if superseded, terminates
+  // the just-created worker instead of adopting it — otherwise the stale worker
+  // leaks a thread and keeps pushing snapshots into a discarded controller.
+  private initGeneration = 0;
 
   constructor(params?: Partial<SimulationParams>, config?: SimulationConfig) {
     this.params = this.getDefaultParams(params);
@@ -149,6 +156,8 @@ export class MonteCarloSimulation implements SimulationController {
     this.params = params;
     this.rng.setSeed(params.seed || Date.now());
     this.dims = { width, height };
+    // New init supersedes any in-flight async worker creation from a prior call.
+    const generation = ++this.initGeneration;
 
     // Determine which implementation to use based on size
     const size = Math.min(width, height);
@@ -221,6 +230,14 @@ export class MonteCarloSimulation implements SimulationController {
           },
         )
           .then((workerSim) => {
+            // A newer initialize()/dispose() ran while this promise was pending.
+            // Adopting the worker now would leak it (the controller has moved on)
+            // and clobber the current state, so terminate it and bail.
+            if (generation !== this.initGeneration) {
+              workerSim?.stop();
+              workerSim?.terminate();
+              return;
+            }
             if (workerSim) {
               this.workerSim = workerSim;
               this.workerActive = true;
@@ -239,6 +256,10 @@ export class MonteCarloSimulation implements SimulationController {
             }
           })
           .catch((error) => {
+            // Don't fall back if a newer init has already taken over.
+            if (generation !== this.initGeneration) {
+              return;
+            }
             console.warn(
               'Failed to create worker, falling back to optimized implementation',
               error,
@@ -346,6 +367,9 @@ export class MonteCarloSimulation implements SimulationController {
   dispose(): void {
     this.isRunningFlag = false;
     this.pendingRun = false;
+    // Supersede any in-flight worker creation so its async resolution terminates
+    // the worker instead of adopting it after we've torn down.
+    this.initGeneration++;
     if (this.workerSim) {
       this.workerSim.stop();
       this.workerSim.terminate();

--- a/client/tests/six-vertex/workerLifecycle.test.ts
+++ b/client/tests/six-vertex/workerLifecycle.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Worker lifecycle / async-cache regression tests for the simulation facade.
+ *
+ * The real workerInterface uses `new Worker(new URL(..., import.meta.url))`,
+ * which ts-jest (CommonJS) cannot parse — so the facade was historically
+ * untestable in Jest. We mock the whole workerInterface module here: the real
+ * file is never evaluated (no import.meta), and we get full control over when
+ * the async createWorkerSimulation() promise resolves. That lets us exercise
+ * the generation-token guard that prevents leaking a worker when a newer
+ * initialize()/dispose() lands while creation is still in flight (#69).
+ */
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { BoundaryCondition } from '../../src/lib/six-vertex/types';
+import type { SimulationParams } from '../../src/lib/six-vertex/types';
+
+// Captured resolvers for each createWorkerSimulation() call, in order. Prefixed
+// `mock` so jest's hoisted mock factory may reference it.
+const mockResolvers: Array<(w: unknown) => void> = [];
+
+jest.mock('../../src/lib/six-vertex/worker/workerInterface', () => ({
+  isWorkerSupported: () => true,
+  WorkerSimulation: class {},
+  createWorkerSimulation: jest.fn(
+    () =>
+      new Promise((resolve) => {
+        mockResolvers.push(resolve as (w: unknown) => void);
+      }),
+  ),
+}));
+
+// Imported AFTER the mock is registered.
+import { MonteCarloSimulation } from '../../src/lib/six-vertex/simulation';
+
+interface FakeWorker {
+  stop: jest.Mock;
+  terminate: jest.Mock;
+  getRawState: jest.Mock;
+  getStats: jest.Mock;
+  startContinuous: jest.Mock;
+  step: jest.Mock;
+  setState: jest.Mock;
+}
+
+function makeFakeWorker(): FakeWorker {
+  return {
+    stop: jest.fn(),
+    terminate: jest.fn(),
+    getRawState: jest.fn(),
+    getStats: jest.fn(),
+    startContinuous: jest.fn(),
+    step: jest.fn(),
+    setState: jest.fn(),
+  };
+}
+
+// A lattice above LARGE_LATTICE_THRESHOLD (128) so worker mode engages.
+const SIZE = 256;
+const params: SimulationParams = {
+  temperature: 1,
+  beta: 1,
+  weights: { a1: 1, a2: 1, b1: 1, b2: 1, c1: 1, c2: 1 },
+  boundaryCondition: BoundaryCondition.DWBC,
+  dwbcConfig: { type: 'high' },
+  seed: 7,
+};
+
+// Flush both microtasks (promise .then) and the macrotask queue.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('worker async-init generation guard (#69)', () => {
+  beforeEach(() => {
+    mockResolvers.length = 0;
+  });
+
+  it('terminates a worker that resolves after dispose() (no leak)', async () => {
+    const sim = new MonteCarloSimulation({ seed: 7 }, { useWorker: true, useOptimized: true });
+    sim.initialize(SIZE, SIZE, params);
+    expect(mockResolvers).toHaveLength(1);
+
+    // Controller is discarded before the worker finishes spinning up.
+    sim.dispose();
+
+    const stale = makeFakeWorker();
+    mockResolvers[0](stale);
+    await flush();
+
+    // The late worker must be stopped + terminated, never adopted.
+    expect(stale.terminate).toHaveBeenCalledTimes(1);
+    expect(stale.startContinuous).not.toHaveBeenCalled();
+  });
+
+  it('terminates the superseded worker when initialize() runs again', async () => {
+    const sim = new MonteCarloSimulation({ seed: 7 }, { useWorker: true, useOptimized: true });
+    sim.initialize(SIZE, SIZE, params); // generation 1
+    sim.initialize(SIZE, SIZE, params); // generation 2 supersedes 1
+    expect(mockResolvers).toHaveLength(2);
+
+    const first = makeFakeWorker();
+    const second = makeFakeWorker();
+
+    mockResolvers[0](first);
+    await flush();
+    expect(first.terminate).toHaveBeenCalledTimes(1); // stale → killed
+
+    mockResolvers[1](second);
+    await flush();
+    expect(second.terminate).not.toHaveBeenCalled(); // current → adopted
+    expect(second.getRawState).toHaveBeenCalled(); // seeded the cache
+  });
+
+  it('honours a run() requested before the worker finished initializing', async () => {
+    const sim = new MonteCarloSimulation({ seed: 7 }, { useWorker: true, useOptimized: true });
+    sim.initialize(SIZE, SIZE, params);
+
+    // User presses Run while the worker is still being created.
+    void sim.run(Number.MAX_SAFE_INTEGER);
+
+    const worker = makeFakeWorker();
+    mockResolvers[0](worker);
+    await flush();
+
+    expect(worker.terminate).not.toHaveBeenCalled();
+    expect(worker.startContinuous).toHaveBeenCalled(); // pending run honoured
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-73.dev.6v.allison.la

## Summary
Fixes two resource leaks surfaced by the #63 adversarial audit (both tracked in #69): a Web Worker thread leak on async-init races, and an orphaned `requestAnimationFrame` loop after Pause.

## Changes
- **Worker async-init race** (`simulation.ts`): `createWorkerSimulation()` is async, so a second `initialize()` (size/seed/boundary change) or `dispose()` could land while the first promise was still pending — the stale promise then adopted its worker, leaking a thread that kept pushing snapshots into a discarded controller. Added a monotonic `initGeneration` token captured per `initialize()`; the async resolution **terminates** the just-created worker instead of adopting it when superseded. `dispose()` bumps the token too.
- **Orphaned FPS rAF loop** (`MainSimulator.tsx`): the FPS counter self-gated on the `isRunning` closure (captured at effect-run time, never updated), so after Pause it kept scheduling `requestAnimationFrame` forever and leaked across every subsequent run. The loop is now owned by the effect and cancelled in cleanup; FPS resets to 0 on pause.
- **Test** (`workerLifecycle.test.ts`): mocks the `workerInterface` module — sidestepping the `import.meta.url` that previously made the facade untestable in ts-jest — to deterministically cover the generation guard (terminate-on-supersede via both re-init and dispose) and the pending-run handoff.

## Testing
- [x] Unit tests pass (351, +3 new)
- [x] `tsc --noEmit` clean
- [x] ESLint clean
- [x] Production build succeeds
- [x] No regressions identified

## Related Issues
Refs #69

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated
- [x] Single responsibility (resource-leak fixes only)
- [x] CI checks pass