### PR TITLE
perf: cache ImageData + memoize renderConfig (#69)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react';
+import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import type {
   SimulationController,
   LatticeState,
@@ -504,15 +504,22 @@ function MainSimulator() {
     }
   }, [isRunning, runSimulation]);
 
-  // Render config with theme-aware colors
-  const renderConfig: Partial<RenderConfig> = {
-    mode: renderMode,
-    showGrid,
-    animateFlips,
-    cellSize: 30,
-    lineWidth: 2,
-    colors: getThemeColors(isDarkMode),
-  };
+  // Render config with theme-aware colors. Memoized so its identity is stable
+  // across the many re-renders a run triggers (one per stats/state update). An
+  // unstable identity made VisualizationCanvas's config-and-draw effect re-run
+  // every frame, forcing a redundant full redraw on top of the one the
+  // onStateChange handler already performs.
+  const renderConfig: Partial<RenderConfig> = useMemo(
+    () => ({
+      mode: renderMode,
+      showGrid,
+      animateFlips,
+      cellSize: 30,
+      lineWidth: 2,
+      colors: getThemeColors(isDarkMode),
+    }),
+    [renderMode, showGrid, animateFlips, isDarkMode],
+  );
 
   return (
     <div className="main-content">

--- a/client/src/lib/six-vertex/renderer/latticeBitmap.ts
+++ b/client/src/lib/six-vertex/renderer/latticeBitmap.ts
@@ -23,6 +23,16 @@ const VERTEX_RGB: ReadonlyArray<readonly [number, number, number]> = [
   [0xcc, 0x79, 0xa7], // c2
 ];
 
+// Per-context ImageData cache. At 1024x1024 each ImageData backs a 4 MB buffer;
+// allocating a fresh one every animation frame churns the GC hard during a run.
+// We keep one buffer per canvas context, reusing it whenever the lattice
+// dimensions are unchanged (the common case — only the pixel data varies). Keyed
+// by the context via a WeakMap so a discarded canvas's buffer is collectable.
+const imageDataCache = new WeakMap<
+  CanvasRenderingContext2D,
+  { width: number; height: number; img: ImageData }
+>();
+
 /**
  * Paint a flat row-major Int8Array of numeric vertex types into the context,
  * one pixel per vertex. `vertices` must have at least width*height entries.
@@ -34,7 +44,14 @@ export function paintLatticeBitmap(
   vertices: Int8Array,
 ): void {
   const count = width * height;
-  const img = ctx.createImageData(width, height);
+  const cached = imageDataCache.get(ctx);
+  let img: ImageData;
+  if (cached && cached.width === width && cached.height === height) {
+    img = cached.img;
+  } else {
+    img = ctx.createImageData(width, height);
+    imageDataCache.set(ctx, { width, height, img });
+  }
   const data = img.data;
   for (let i = 0; i < count; i++) {
     const rgb = VERTEX_RGB[vertices[i]] ?? VERTEX_RGB[0];

--- a/client/tests/six-vertex/rawState.test.ts
+++ b/client/tests/six-vertex/rawState.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 // Test the engine directly (OptimizedPhysicsSimulation) rather than the
 // MonteCarloSimulation facade: the facade transitively imports the Web Worker
 // module, whose import.meta.url is incompatible with the ts-jest module target.
@@ -133,5 +133,44 @@ describe('latticeBitmap', () => {
         255,
       ]);
     }
+  });
+
+  it('reuses one ImageData per context across same-size repaints, reallocating only on resize', () => {
+    const createImageData = jest.fn((w: number, h: number) => ({
+      width: w,
+      height: h,
+      data: new Uint8ClampedArray(w * h * 4),
+      colorSpace: 'srgb' as PredefinedColorSpace,
+    }));
+    const ctx = {
+      createImageData,
+      putImageData: () => {},
+    } as unknown as CanvasRenderingContext2D;
+
+    const frame = Int8Array.from([0, 1, 2, 3]); // 2x2
+    paintLatticeBitmap(ctx, 2, 2, frame);
+    paintLatticeBitmap(ctx, 2, 2, frame);
+    paintLatticeBitmap(ctx, 2, 2, frame);
+    // Same dimensions → buffer reused, allocated exactly once (no per-frame churn).
+    expect(createImageData).toHaveBeenCalledTimes(1);
+
+    // Dimension change → must allocate a correctly-sized buffer.
+    paintLatticeBitmap(ctx, 3, 3, Int8Array.from([0, 1, 2, 3, 4, 5, 0, 1, 2]));
+    expect(createImageData).toHaveBeenCalledTimes(2);
+    expect(createImageData).toHaveBeenLastCalledWith(3, 3);
+
+    // A different context gets its own cached buffer (WeakMap keyed by context).
+    const createImageData2 = jest.fn((w: number, h: number) => ({
+      width: w,
+      height: h,
+      data: new Uint8ClampedArray(w * h * 4),
+      colorSpace: 'srgb' as PredefinedColorSpace,
+    }));
+    const ctx2 = {
+      createImageData: createImageData2,
+      putImageData: () => {},
+    } as unknown as CanvasRenderingContext2D;
+    paintLatticeBitmap(ctx2, 2, 2, frame);
+    expect(createImageData2).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-74.dev.6v.allison.la

## Summary
Cuts redundant per-frame work in the render loop, surfaced by the #63 audit (tracked in #69): a multi-MB ImageData allocation every frame, and a redundant full redraw caused by an unstable `renderConfig` identity.

## Changes
- **ImageData cache** (`latticeBitmap.ts`): `paintLatticeBitmap` allocated a fresh `ImageData` each frame (~4 MB at 1024²), churning the GC during a run. Now caches one buffer per canvas context in a `WeakMap` and reuses it while dimensions are unchanged (only pixel data varies — every RGBA byte is overwritten, so reuse is safe). Resize reallocates; a discarded canvas's buffer stays collectable.
- **Memoized `renderConfig`** (`MainSimulator.tsx`): the config object (with a fresh `getThemeColors()`) was rebuilt on every render. Since a run re-renders once per stats/state update, the unstable identity made `VisualizationCanvas`'s config-and-draw effect re-run every frame — a redundant full redraw on top of the `onStateChange` redraw. Now `useMemo`'d on `[renderMode, showGrid, animateFlips, isDarkMode]`.

## Testing
- [x] Unit tests pass (352, +1 new cache-reuse regression test)
- [x] `tsc --noEmit` clean, ESLint clean
- [x] Production build succeeds
- [x] No behavioral change to rendered output (pixels identical; only allocation/redraw frequency changes)

## Related Issues
Refs #69

## Checklist
- [x] Single responsibility (render performance only)
- [x] Tests added/updated
- [x] CI checks pass