### PR TITLE
fix: honest stats — finite energy + truthful c₂-count label (#69)

### DIFF
--- a/client/src/components/StatisticsPanel.tsx
+++ b/client/src/components/StatisticsPanel.tsx
@@ -244,10 +244,10 @@ const StatisticsPanel: React.FC<StatisticsPanelProps> = ({
           <div className="stats-grid">
             <div
               className="stat-item"
-              title="Height-function value tracked by the model as flips occur (related to the number of c-type vertices); grows as the disordered region fills in."
+              title="Number of c₂ vertices in the lattice — a scalar order parameter the engine tracks incrementally and uses as the convergence observable. (This is a c₂ count, not the model's 2D height function.)"
             >
-              <span className="stat-label">Height</span>
-              <span className="stat-value">{stats.height?.toFixed(2) ?? 'N/A'}</span>
+              <span className="stat-label">c₂ Count</span>
+              <span className="stat-value">{stats.height?.toFixed(0) ?? 'N/A'}</span>
             </div>
             {delta !== undefined && delta !== null && (
               <div

--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -566,10 +566,16 @@ export class OptimizedPhysicsSimulation {
       vertexCounts[this.vertices[i]]++;
     }
 
-    // Calculate energy
+    // Calculate energy E = -Σ count_i · ln(w_i). Skip empty types: a type with
+    // zero count contributes nothing, and including it would compute
+    // 0 · ln(0) = NaN whenever a forbidden (weight-0) type is simply absent —
+    // poisoning the whole energy readout. A weight-0 type that IS present still
+    // yields +Infinity, which is the physically correct "forbidden config" cost.
     let energy = 0;
     for (let i = 0; i < 6; i++) {
-      energy -= vertexCounts[i] * Math.log(this.weights[i]);
+      if (vertexCounts[i] > 0) {
+        energy -= vertexCounts[i] * Math.log(this.weights[i]);
+      }
     }
 
     const acceptanceRate = this.attemptedFlips > 0 ? this.successfulFlips / this.attemptedFlips : 0;

--- a/client/src/lib/six-vertex/stopConditions.ts
+++ b/client/src/lib/six-vertex/stopConditions.ts
@@ -41,10 +41,12 @@ export interface StopConditionDescriptor {
 const EPSILON = 1e-9;
 
 /**
- * Macroscopic observable used to compare instances. Prefers the engine-reported
- * height when present, otherwise falls back to the c2 vertex count. This is a
- * COARSE proxy for the macroscopic configuration (height ~ Arctic-curve volume);
- * relative spread (below) handles its scale, so no normalization is needed.
+ * Macroscopic observable used to compare instances: the c₂ vertex count. The
+ * optimized engine reports this incrementally as `stats.height` (a scalar order
+ * parameter, NOT the model's 2D height function); we fall back to the directly
+ * counted c₂ total when that field is absent. It is a COARSE proxy for the
+ * macroscopic configuration; relative spread (below) handles its scale, so no
+ * normalization is needed.
  */
 export function heightObservable(stats: SimulationStats): number {
   if (typeof stats.height === 'number') {

--- a/client/tests/six-vertex/optimizedEngine.test.ts
+++ b/client/tests/six-vertex/optimizedEngine.test.ts
@@ -142,3 +142,32 @@ describe('equilibrium responds correctly to weights (#69 acceptance rule)', () =
     expect(adom.getStats().acceptanceRate).toBeGreaterThan(0);
   });
 });
+
+describe('energy stat is finite when a vertex type has weight 0 (#69)', () => {
+  it('does not return NaN energy for an absent zero-weight type', () => {
+    // DWBC-low contains only a1/a2/c2 — no b vertices. Setting b weights to 0
+    // means count=0 AND weight=0, which previously computed 0 * ln(0) = NaN and
+    // poisoned the whole energy readout.
+    const sim = new OptimizedPhysicsSimulation({
+      size: 8,
+      weights: { a1: 1, a2: 1, b1: 0, b2: 0, c1: 1, c2: 1 },
+      seed: 1,
+      initialState: 'dwbc-low',
+    });
+    const energy = sim.getStats().energy;
+    expect(Number.isNaN(energy)).toBe(false);
+    expect(Number.isFinite(energy)).toBe(true);
+  });
+
+  it('stays finite after stepping with a zero-weight absent type', () => {
+    const sim = new OptimizedPhysicsSimulation({
+      size: 8,
+      weights: { a1: 2, a2: 2, b1: 0, b2: 0, c1: 1, c2: 1 },
+      seed: 7,
+      initialState: 'dwbc-low',
+    });
+    sim.run(5000);
+    const energy = sim.getStats().energy;
+    expect(Number.isNaN(energy)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-75.dev.6v.allison.la

## Summary
Two stats-honesty fixes from the #63 audit (tracked in #69), continuing the project's "no fake/misleading UI values" principle: the Energy readout could go `NaN`, and the "Height" stat was actually a c₂ vertex count mislabeled as the model's height function.

## Changes
- **Energy NaN guard** (`optimizedSimulation.ts`): `getStats()` summed `-count·ln(weight)` over all six types. A type with weight 0 **and** zero occurrences (e.g. b types under a DWBC-low start) computed `0·ln(0) = NaN`, poisoning the whole energy value. Now skips empty types; a weight-0 type that is genuinely present still yields `+Infinity` (the correct forbidden-config cost).
- **Truthful "Height" label** (`StatisticsPanel.tsx`): the engine's `height` field is literally the running **c₂ vertex count** (init = c₂ total, updated by the c₂ delta per flip), not the model's 2D height function. Relabeled "Height" → "c₂ Count", shown as an integer, with an accurate tooltip noting it's a scalar order parameter used for convergence.
- **Doc accuracy** (`stopConditions.ts`): clarified `heightObservable()` describes the c₂-count order parameter, not an Arctic-curve volume.

## Testing
- [x] Unit tests pass (354, +2 new energy-finiteness regression tests)
- [x] `tsc --noEmit` clean; ESLint clean (pre-existing `any` warnings only)
- [x] Production build succeeds

## Related Issues
Refs #69

## Checklist
- [x] Single responsibility (stats correctness/honesty only)
- [x] Tests added/updated
- [x] CI checks pass