### PR TITLE
fix: worker 'step' advances exactly one MC step (#69)

### DIFF
--- a/client/src/lib/six-vertex/worker/simulationWorker.ts
+++ b/client/src/lib/six-vertex/worker/simulationWorker.ts
@@ -117,9 +117,6 @@ type WorkerResponse =
 let simulation: OptimizedPhysicsSimulation | null = null;
 let continuousRunning = false;
 let animationFrame: number | null = null;
-// Batch size used for a single 'step' message and for continuous animate ticks.
-// Kept in sync with the engine's configured batchSize when available.
-let stepBatchSize = 100;
 
 /**
  * Handle messages from the main thread
@@ -178,7 +175,6 @@ self.addEventListener('message', (event: MessageEvent<WorkerMessage>) => {
  */
 function handleInit(config: OptimizedSimConfig): void {
   simulation = new OptimizedPhysicsSimulation(config);
-  stepBatchSize = config.batchSize && config.batchSize > 0 ? config.batchSize : 100;
   sendResponse({ type: 'ready' });
   sendStats();
   sendRawState();
@@ -222,7 +218,11 @@ function handleStep(): void {
     return;
   }
 
-  simulation.run(stepBatchSize);
+  // A single 'step' message must advance exactly one Monte Carlo step, matching
+  // the main-thread path (optimizedSim.run(1)). Previously the worker ran a full
+  // batch (~100), so the Step button jumped ~100x further on large (worker)
+  // lattices than on small ones — inconsistent, surprising step semantics.
+  simulation.run(1);
   sendStats();
   sendRawState();
 }

--- a/client/tests/six-vertex/optimizedEngine.test.ts
+++ b/client/tests/six-vertex/optimizedEngine.test.ts
@@ -171,3 +171,19 @@ describe('energy stat is finite when a vertex type has weight 0 (#69)', () => {
     expect(Number.isNaN(energy)).toBe(false);
   });
 });
+
+describe('single-step contract shared by main-thread and worker step (#69)', () => {
+  it('run(1) advances the step counter by exactly one', () => {
+    const sim = new OptimizedPhysicsSimulation({
+      size: 16,
+      weights: EQUAL,
+      seed: 3,
+      initialState: 'dwbc-high',
+    });
+    expect(sim.getStats().step).toBe(0);
+    sim.run(1);
+    expect(sim.getStats().step).toBe(1);
+    sim.run(1);
+    expect(sim.getStats().step).toBe(2);
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-76.dev.6v.allison.la

## Summary
Makes the Step button mean the same thing everywhere. The worker's `handleStep` ran a full batch (~100 steps) while the main thread runs `run(1)`, so a single Step jumped ~100× further on large (worker) lattices than on small ones (#63 audit, tracked in #69).

## Changes
- `simulationWorker.ts`: `handleStep` now calls `simulation.run(1)` — one Monte Carlo step, matching the main-thread path. Removed the now-unused `stepBatchSize` (continuous animation already uses its own adaptive batch).
- Test: pins the shared single-step contract — `run(1)` advances the step counter by exactly one.

## Testing
- [x] Unit tests pass (355, +1 new)
- [x] `tsc --noEmit` clean; ESLint clean (pre-existing `any` warnings only)
- [x] Production build succeeds

## Related Issues
Refs #69

## Checklist
- [x] Single responsibility (step granularity only)
- [x] Tests added/updated
- [x] CI checks pass