### PR TITLE
fix: validate dimensions + vertex byte range on import (#69)

### DIFF
--- a/client/src/lib/six-vertex/serialization.ts
+++ b/client/src/lib/six-vertex/serialization.ts
@@ -13,6 +13,11 @@ import { getVertexConfiguration } from './types';
 export const SIXV_FORMAT = '6v-lattice';
 export const SIXV_VERSION = 1;
 
+// Upper bound on a single lattice dimension when parsing untrusted input, to
+// reject absurd sizes before allocating width*height bytes. Generously above
+// the app's 1024×1024 working ceiling.
+export const MAX_DIMENSION = 4096;
+
 // Numeric vertex ids ↔ VertexType, matching cStyleFlipLogic (a1=0 … c2=5).
 const NUM_TO_TYPE: VertexType[] = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'] as VertexType[];
 const TYPE_TO_NUM: Record<string, number> = { a1: 0, a2: 1, b1: 2, b2: 3, c1: 4, c2: 5 };
@@ -116,9 +121,34 @@ export function deserializeSimulation(input: unknown): SimulationData {
   ) {
     throw new SixVParseError('File is missing required fields.');
   }
+  // Validate dimensions BEFORE decoding: reject non-positive/fractional values
+  // and absurd sizes (this input may come from an untrusted file or
+  // localStorage; width*height bounds the allocation below).
+  if (
+    !Number.isInteger(file.width) ||
+    !Number.isInteger(file.height) ||
+    file.width <= 0 ||
+    file.height <= 0
+  ) {
+    throw new SixVParseError('Lattice dimensions must be positive integers.');
+  }
+  if (file.width > MAX_DIMENSION || file.height > MAX_DIMENSION) {
+    throw new SixVParseError(
+      `Lattice dimensions exceed the maximum supported size (${MAX_DIMENSION}).`,
+    );
+  }
   const bytes = base64ToBytes(file.vertices);
   if (bytes.length !== file.width * file.height) {
     throw new SixVParseError('Vertex data length does not match width × height.');
+  }
+  // Every byte must be a valid vertex code (0–5). Previously out-of-range bytes
+  // were silently coerced to a1, masking corrupt/malicious input.
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] > 5) {
+      throw new SixVParseError(
+        `Vertex data contains an invalid vertex code ${bytes[i]} at index ${i} (expected 0–5).`,
+      );
+    }
   }
   const latticeState = bytesToLattice(bytes, file.width, file.height);
   return {

--- a/client/tests/six-vertex/serialization.test.ts
+++ b/client/tests/six-vertex/serialization.test.ts
@@ -99,6 +99,31 @@ describe('serialization format guards', () => {
     const file = serializeSimulation(makeData(8));
     expect(() => deserializeSimulation({ ...file, width: 9 })).toThrow(/length/i);
   });
+
+  it('rejects non-positive or fractional dimensions', () => {
+    const file = serializeSimulation(makeData(8));
+    expect(() => deserializeSimulation({ ...file, width: 0 })).toThrow(/positive integer/i);
+    expect(() => deserializeSimulation({ ...file, height: -8 })).toThrow(/positive integer/i);
+    expect(() => deserializeSimulation({ ...file, width: 8.5 })).toThrow(/positive integer/i);
+  });
+
+  it('rejects absurd dimensions before allocating', () => {
+    const file = serializeSimulation(makeData(8));
+    expect(() => deserializeSimulation({ ...file, width: 1_000_000, height: 1_000_000 })).toThrow(
+      /maximum supported size/i,
+    );
+  });
+
+  it('rejects out-of-range vertex codes instead of silently coercing them', () => {
+    const file = serializeSimulation(makeData(4));
+    // Corrupt one byte to 200 (invalid; valid codes are 0–5) and re-encode.
+    const raw = Uint8Array.from(atob(file.vertices), (ch) => ch.charCodeAt(0));
+    raw[0] = 200;
+    let bin = '';
+    for (const b of raw) bin += String.fromCharCode(b);
+    const corrupted = { ...file, vertices: btoa(bin) };
+    expect(() => deserializeSimulation(corrupted)).toThrow(/invalid vertex code/i);
+  });
 });
 
 describe('CSV export', () => {


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-78.dev.6v.allison.la

## Summary
Hardens `deserializeSimulation` against untrusted input (uploaded files / localStorage). Previously out-of-range vertex bytes were silently coerced to `a1` and lattice dimensions were never validated before allocating `width × height` bytes (#63 audit, tracked in #69).

## Changes
- `serialization.ts`: reject (with a clear `SixVParseError`) non-positive/fractional dimensions, dimensions above `MAX_DIMENSION` (4096, generously above the 1024 ceiling) **before** decoding, and any decoded byte outside the valid vertex range 0–5 (no more silent coercion that masks corruption).
- Tests for each rejection path.

## Testing
- [x] Unit tests pass (358, +3 new)
- [x] `tsc --noEmit` clean; ESLint clean
- [x] Production build succeeds

## Related Issues
Refs #69

## Checklist
- [x] Single responsibility (import validation only)
- [x] Tests added/updated
- [x] CI checks pass