### PR TITLE
fix: correct b1/b2/c1/c2 arrow configurations to canonical Fig. 1 table (#77)

### DIFF
--- a/client/src/lib/six-vertex/dwbcCorrectIce.ts
+++ b/client/src/lib/six-vertex/dwbcCorrectIce.ts
@@ -1,276 +1,126 @@
 /**
- * DWBC Implementation with correct Ice Rule
+ * DWBC initial-state generators (Fig. 2 / Fig. 3 of arXiv:cond-mat/0502314v1).
  *
- * This implementation carefully constructs DWBC states that satisfy the ice rule
- * by ensuring edge consistency between neighboring vertices.
+ * The vertex-type pattern is taken straight from the paper's matrices; the arrow
+ * directions come from the single source of truth, getVertexConfiguration(). The
+ * shared edge arrays are then derived from those configurations so that every
+ * shared edge is consistent by construction (verified in edgeConsistency.test.ts).
  */
 
 import type { LatticeState, Vertex, VertexConfiguration } from './types';
-import { VertexType, EdgeState } from './types';
+import { VertexType, EdgeState, getVertexConfiguration } from './types';
 
-/**
- * Helper to get the correct vertex configuration for each type
- * These are based on Figure 1 from the paper
- */
-function getCorrectConfiguration(type: VertexType): VertexConfiguration {
-  switch (type) {
-    case VertexType.a1:
-      // Left & top in, right & bottom out
-      return {
-        left: EdgeState.In,
-        top: EdgeState.In,
-        right: EdgeState.Out,
-        bottom: EdgeState.Out,
-      };
+const oppositeOf = (e: EdgeState): EdgeState => (e === EdgeState.In ? EdgeState.Out : EdgeState.In);
 
-    case VertexType.a2:
-      // Right & bottom in, left & top out
-      return {
-        right: EdgeState.In,
-        bottom: EdgeState.In,
-        left: EdgeState.Out,
-        top: EdgeState.Out,
-      };
-
-    case VertexType.b1:
-      // Left & right in, top & bottom out
-      return {
-        left: EdgeState.In,
-        right: EdgeState.In,
-        top: EdgeState.Out,
-        bottom: EdgeState.Out,
-      };
-
-    case VertexType.b2:
-      // Top & bottom in, left & right out
-      return {
-        top: EdgeState.In,
-        bottom: EdgeState.In,
-        left: EdgeState.Out,
-        right: EdgeState.Out,
-      };
-
-    case VertexType.c1:
-      // Left & bottom in, right & top out
-      return {
-        left: EdgeState.In,
-        bottom: EdgeState.In,
-        right: EdgeState.Out,
-        top: EdgeState.Out,
-      };
-
-    case VertexType.c2:
-      // Right & top in, left & bottom out
-      return {
-        right: EdgeState.In,
-        top: EdgeState.In,
-        left: EdgeState.Out,
-        bottom: EdgeState.Out,
-      };
+/** A lattice size must be a non-negative integer. */
+function assertValidSize(size: number): void {
+  if (!Number.isInteger(size) || size < 0) {
+    throw new RangeError(`Invalid lattice size: ${size} (expected a non-negative integer)`);
   }
 }
 
 /**
- * Generate DWBC High with correct ice rule
+ * Build fully-populated, edge-consistent horizontal/vertical edge arrays from a
+ * grid of vertex types, using the lattice edge convention shared with
+ * initialStates.ts:
+ *   - horizontalEdges has `size` rows of `size + 1` entries; the entry to the
+ *     right of vertex (r,c) is stored directly as that vertex's `right` state,
+ *     and a vertex reads its `left` as the opposite of the entry on its left.
+ *   - verticalEdges has `size + 1` rows of `size` entries; the entry below
+ *     vertex (r,c) is stored directly as that vertex's `bottom` state, and a
+ *     vertex reads its `top` as the opposite of the entry above it.
+ * Because neighbouring configurations agree on every shared edge, the directly
+ * stored value and the "opposite of the neighbour" value coincide.
+ */
+function buildEdges(vertexTypes: VertexType[][], size: number) {
+  const horizontalEdges: EdgeState[][] = Array.from(
+    { length: size },
+    () => new Array<EdgeState>(size + 1),
+  );
+  const verticalEdges: EdgeState[][] = Array.from(
+    { length: size + 1 },
+    () => new Array<EdgeState>(size),
+  );
+
+  for (let row = 0; row < size; row++) {
+    for (let col = 0; col < size; col++) {
+      const cfg = getVertexConfiguration(vertexTypes[row][col]);
+      horizontalEdges[row][col + 1] = cfg.right;
+      verticalEdges[row + 1][col] = cfg.bottom;
+      if (col === 0) horizontalEdges[row][0] = oppositeOf(cfg.left);
+      if (row === 0) verticalEdges[0][col] = oppositeOf(cfg.top);
+    }
+  }
+
+  return { horizontalEdges, verticalEdges };
+}
+
+function buildVertices(vertexTypes: VertexType[][], size: number): Vertex[][] {
+  const vertices: Vertex[][] = [];
+  for (let row = 0; row < size; row++) {
+    vertices[row] = [];
+    for (let col = 0; col < size; col++) {
+      const type = vertexTypes[row][col];
+      const configuration: VertexConfiguration = getVertexConfiguration(type);
+      vertices[row][col] = { position: { row, col }, type, configuration };
+    }
+  }
+  return vertices;
+}
+
+/**
+ * DWBC High (Fig. 2): c2 on the anti-diagonal, b1 upper-left, b2 lower-right.
  */
 export function generateDWBCHighCorrectIce(size: number): LatticeState {
-  // First, determine the vertex type pattern
+  assertValidSize(size);
   const vertexTypes: VertexType[][] = [];
   for (let row = 0; row < size; row++) {
     vertexTypes[row] = [];
     for (let col = 0; col < size; col++) {
       if (row + col === size - 1) {
-        vertexTypes[row][col] = VertexType.c2; // Anti-diagonal
+        vertexTypes[row][col] = VertexType.c2; // anti-diagonal
       } else if (row + col < size - 1) {
-        vertexTypes[row][col] = VertexType.b1; // Upper-left
+        vertexTypes[row][col] = VertexType.b1; // upper-left
       } else {
-        vertexTypes[row][col] = VertexType.b2; // Lower-right
+        vertexTypes[row][col] = VertexType.b2; // lower-right
       }
     }
   }
 
-  // Initialize edges - using the lattice edge convention
-  // horizontalEdges[row][col] is the edge to the left of vertex (row,col)
-  // verticalEdges[row][col] is the edge above vertex (row,col)
-  // Use literal strings to avoid any type issues
-  const horizontalEdges: EdgeState[][] = Array(size)
-    .fill(null)
-    .map(() => Array(size + 1).fill('out' as EdgeState));
-  const verticalEdges: EdgeState[][] = Array(size + 1)
-    .fill(null)
-    .map(() => Array(size).fill('out' as EdgeState));
-
-  // For DWBC High, we need specific boundary conditions
-  // These are from the lattice perspective (not vertex perspective)
-
-  // Top boundary: arrows point down into lattice
-  for (let col = 0; col < size; col++) {
-    verticalEdges[0][col] = 'in' as EdgeState;
-  }
-
-  // Bottom boundary: arrows point down out of lattice
-  for (let col = 0; col < size; col++) {
-    verticalEdges[size][col] = 'out' as EdgeState;
-  }
-
-  // Left boundary: arrows point right into lattice
-  for (let row = 0; row < size; row++) {
-    horizontalEdges[row][0] = 'out' as EdgeState;
-  }
-
-  // Right boundary: arrows point right out of lattice
-  for (let row = 0; row < size; row++) {
-    horizontalEdges[row][size] = 'in' as EdgeState;
-  }
-
-  // Now we need to fill in the internal edges consistently
-  // We'll process vertices in a specific order to ensure consistency
-  const vertices: Vertex[][] = [];
-
-  // Process row by row, left to right
-  for (let row = 0; row < size; row++) {
-    vertices[row] = [];
-    for (let col = 0; col < size; col++) {
-      const type = vertexTypes[row][col];
-
-      // For internal edges that haven't been set, use the ideal configuration
-      if (col < size - 1 && row > 0 && row < size - 1) {
-        // Internal right edge - set based on vertex type requirement
-        if (type === VertexType.b1) {
-          horizontalEdges[row][col + 1] = 'in' as EdgeState; // b1 needs right in
-        } else if (type === VertexType.b2) {
-          horizontalEdges[row][col + 1] = 'out' as EdgeState; // b2 needs right out
-        } else if (type === VertexType.c2) {
-          horizontalEdges[row][col + 1] = 'in' as EdgeState; // c2 needs right in
-        }
-      }
-
-      if (row < size - 1 && col > 0 && col < size - 1) {
-        // Internal bottom edge - set based on vertex type requirement
-        if (type === VertexType.b1) {
-          verticalEdges[row + 1][col] = 'out' as EdgeState; // b1 needs bottom out
-        } else if (type === VertexType.b2) {
-          verticalEdges[row + 1][col] = 'in' as EdgeState; // b2 needs bottom in
-        } else if (type === VertexType.c2) {
-          verticalEdges[row + 1][col] = 'out' as EdgeState; // c2 needs bottom out
-        }
-      }
-
-      // The canonical 2-in/2-out configuration for this vertex type (Fig. 1),
-      // which guarantees the ice rule. The boundary/internal edge arrays above
-      // are retained for the arrow-overlay renderer.
-      const configuration = getCorrectConfiguration(type);
-
-      vertices[row][col] = {
-        position: { row, col },
-        type,
-        configuration,
-      };
-    }
-  }
-
+  const { horizontalEdges, verticalEdges } = buildEdges(vertexTypes, size);
   return {
     width: size,
     height: size,
-    vertices,
+    vertices: buildVertices(vertexTypes, size),
     horizontalEdges,
     verticalEdges,
   };
 }
 
 /**
- * Generate DWBC Low with correct ice rule
+ * DWBC Low (Fig. 3): c2 on the main diagonal, a1 upper-right, a2 lower-left.
  */
 export function generateDWBCLowCorrectIce(size: number): LatticeState {
-  // Determine vertex types
+  assertValidSize(size);
   const vertexTypes: VertexType[][] = [];
   for (let row = 0; row < size; row++) {
     vertexTypes[row] = [];
     for (let col = 0; col < size; col++) {
       if (row === col) {
-        vertexTypes[row][col] = VertexType.c2; // Main diagonal
+        vertexTypes[row][col] = VertexType.c2; // main diagonal
       } else if (row < col) {
-        vertexTypes[row][col] = VertexType.a1; // Upper-right
+        vertexTypes[row][col] = VertexType.a1; // upper-right
       } else {
-        vertexTypes[row][col] = VertexType.a2; // Lower-left
+        vertexTypes[row][col] = VertexType.a2; // lower-left
       }
     }
   }
 
-  // Initialize edges
-  const horizontalEdges: EdgeState[][] = Array(size)
-    .fill(null)
-    .map(() => Array(size + 1).fill('out' as EdgeState));
-  const verticalEdges: EdgeState[][] = Array(size + 1)
-    .fill(null)
-    .map(() => Array(size).fill('out' as EdgeState));
-
-  // DWBC Low boundary conditions
-
-  // Top boundary: arrows point up out of lattice
-  for (let col = 0; col < size; col++) {
-    verticalEdges[0][col] = 'out' as EdgeState;
-  }
-
-  // Bottom boundary: arrows point up into lattice
-  for (let col = 0; col < size; col++) {
-    verticalEdges[size][col] = 'in' as EdgeState;
-  }
-
-  // Left boundary: arrows point left out of lattice
-  for (let row = 0; row < size; row++) {
-    horizontalEdges[row][0] = 'in' as EdgeState;
-  }
-
-  // Right boundary: arrows point left into lattice
-  for (let row = 0; row < size; row++) {
-    horizontalEdges[row][size] = 'out' as EdgeState;
-  }
-
-  // Build vertices and set internal edges
-  const vertices: Vertex[][] = [];
-
-  for (let row = 0; row < size; row++) {
-    vertices[row] = [];
-    for (let col = 0; col < size; col++) {
-      const type = vertexTypes[row][col];
-
-      // Set internal edges based on vertex type
-      if (col < size - 1 && row > 0 && row < size - 1) {
-        if (type === VertexType.a1) {
-          horizontalEdges[row][col + 1] = 'out' as EdgeState; // a1 needs right out
-        } else if (type === VertexType.a2) {
-          horizontalEdges[row][col + 1] = 'in' as EdgeState; // a2 needs right in
-        } else if (type === VertexType.c2) {
-          horizontalEdges[row][col + 1] = 'in' as EdgeState; // c2 needs right in
-        }
-      }
-
-      if (row < size - 1 && col > 0 && col < size - 1) {
-        if (type === VertexType.a1) {
-          verticalEdges[row + 1][col] = 'out' as EdgeState; // a1 needs bottom out
-        } else if (type === VertexType.a2) {
-          verticalEdges[row + 1][col] = 'in' as EdgeState; // a2 needs bottom in
-        } else if (type === VertexType.c2) {
-          verticalEdges[row + 1][col] = 'out' as EdgeState; // c2 needs bottom out
-        }
-      }
-
-      // Canonical 2-in/2-out configuration (Fig. 1), guaranteeing the ice rule.
-      const configuration = getCorrectConfiguration(type);
-
-      vertices[row][col] = {
-        position: { row, col },
-        type,
-        configuration,
-      };
-    }
-  }
-
+  const { horizontalEdges, verticalEdges } = buildEdges(vertexTypes, size);
   return {
     width: size,
     height: size,
-    vertices,
+    vertices: buildVertices(vertexTypes, size),
     horizontalEdges,
     verticalEdges,
   };

--- a/client/src/lib/six-vertex/initialStates.ts
+++ b/client/src/lib/six-vertex/initialStates.ts
@@ -261,3 +261,42 @@ export function validateIceRule(state: LatticeState): boolean {
 
   return true;
 }
+
+/**
+ * Check that every shared edge between adjacent vertices carries one consistent
+ * arrow. A horizontal edge is the right edge of vertex (r,c) and the left edge of
+ * vertex (r,c+1); the two views describe the same physical arrow, so exactly one
+ * of them is "in". (Likewise for vertical edges via bottom/top.) Unlike
+ * validateIceRule, which only checks each vertex in isolation, this catches a
+ * mislabelled vertex configuration that breaks neighbour agreement.
+ *
+ * Returns the list of inconsistent shared edges (empty when the state is valid).
+ */
+export function findEdgeInconsistencies(
+  state: LatticeState,
+): Array<{ kind: 'horizontal' | 'vertical'; row: number; col: number }> {
+  const problems: Array<{ kind: 'horizontal' | 'vertical'; row: number; col: number }> = [];
+  for (let row = 0; row < state.height; row++) {
+    for (let col = 0; col < state.width; col++) {
+      const here = state.vertices[row][col].configuration;
+      if (col + 1 < state.width) {
+        const right = state.vertices[row][col + 1].configuration;
+        // Consistent iff the shared edge is "in" for exactly one of the two.
+        if (here.right === right.left) problems.push({ kind: 'horizontal', row, col });
+      }
+      if (row + 1 < state.height) {
+        const below = state.vertices[row + 1][col].configuration;
+        if (here.bottom === below.top) problems.push({ kind: 'vertical', row, col });
+      }
+    }
+  }
+  return problems;
+}
+
+/**
+ * True when the lattice is both ice-valid per vertex and edge-consistent across
+ * every shared edge.
+ */
+export function validateEdgeConsistency(state: LatticeState): boolean {
+  return findEdgeInconsistencies(state).length === 0;
+}

--- a/client/src/lib/six-vertex/optimizedSimulation.ts
+++ b/client/src/lib/six-vertex/optimizedSimulation.ts
@@ -9,7 +9,7 @@
  * - Object pooling to reduce GC pressure
  */
 
-import { VertexType } from './types';
+import { VertexType, getVertexConfiguration } from './types';
 import { FlipDirection } from './physicsFlips';
 import {
   isFlipValidCStyle as isFlipValid,
@@ -644,19 +644,11 @@ export class OptimizedPhysicsSimulation {
   }
 
   /**
-   * Get vertex configuration from type
+   * Get vertex configuration from type. Delegates to the single source of truth
+   * in types.ts so the object-snapshot arrows match the rest of the app.
    */
-  private getVertexConfiguration(type: VertexType): any {
-    // Simplified configuration for compatibility
-    const configs: Record<VertexType, any> = {
-      [VertexType.a1]: { left: 'in', right: 'out', top: 'in', bottom: 'out' },
-      [VertexType.a2]: { left: 'out', right: 'in', top: 'out', bottom: 'in' },
-      [VertexType.b1]: { left: 'in', right: 'in', top: 'out', bottom: 'out' },
-      [VertexType.b2]: { left: 'out', right: 'out', top: 'in', bottom: 'in' },
-      [VertexType.c1]: { left: 'in', right: 'out', top: 'out', bottom: 'in' },
-      [VertexType.c2]: { left: 'out', right: 'in', top: 'in', bottom: 'out' },
-    };
-    return configs[type];
+  private getVertexConfiguration(type: VertexType) {
+    return getVertexConfiguration(type);
   }
 
   /**

--- a/client/src/lib/six-vertex/types.ts
+++ b/client/src/lib/six-vertex/types.ts
@@ -4,19 +4,28 @@
  */
 
 /**
- * Vertex types based on the 6 allowed ice configurations
- * Named according to the paper conventions:
- * - a1, a2: Source/sink configurations (2 in, 2 out or vice versa)
- * - b1, b2: Straight-through configurations (horizontal or vertical flow)
- * - c1, c2: Turn configurations (flow changes direction)
+ * Vertex types based on the 6 allowed ice configurations.
+ *
+ * Arrow directions (In = toward the vertex, Out = away) are taken from Fig. 1 of
+ * Allison & Reshetikhin (2005), arXiv:cond-mat/0502314v1, in the renderer's
+ * coordinate frame (row 0 at the top, y increasing downward, so "top" = North).
+ * This table is the single source of truth for the whole app and is verified by
+ * three independent checks (see tests/six-vertex/edgeConsistency.test.ts):
+ *   1. every shared edge of the DWBC High/Low grids is consistent (0 violations),
+ *   2. the implied thick-edge set matches main.c draw_vertex, and
+ *   3. the DWBC boundary is "in at top/bottom, out at left/right".
+ *
+ * - a1, a2: straight, parallel through-flow (weight a)
+ * - b1, b2: straight, anti-parallel through-flow (weight b)
+ * - c1, c2: sources / sinks where the path turns (weight c)
  */
 export const VertexType = {
-  a1: 'a1', // In: left, top    | Out: right, bottom
-  a2: 'a2', // In: right, bottom | Out: left, top
-  b1: 'b1', // In: left, right   | Out: top, bottom
-  b2: 'b2', // In: top, bottom   | Out: left, right
-  c1: 'c1', // In: left, bottom  | Out: right, top
-  c2: 'c2', // In: right, top    | Out: left, bottom
+  a1: 'a1', // In: left, top     | Out: right, bottom
+  a2: 'a2', // In: right, bottom  | Out: left, top
+  b1: 'b1', // In: right, top     | Out: left, bottom
+  b2: 'b2', // In: left, bottom   | Out: right, top
+  c1: 'c1', // In: left, right    | Out: top, bottom  (horizontal source/sink)
+  c2: 'c2', // In: top, bottom    | Out: left, right  (vertical source/sink)
 } as const;
 
 export type VertexType = (typeof VertexType)[keyof typeof VertexType];
@@ -274,15 +283,19 @@ export function getVertexType(config: VertexConfiguration): VertexType | null {
     return null;
   }
 
-  // Determine vertex type based on configuration
-  if (left === EdgeState.In && top === EdgeState.In) return VertexType.a1;
-  if (right === EdgeState.In && bottom === EdgeState.In) return VertexType.a2;
-  if (left === EdgeState.In && right === EdgeState.In) return VertexType.b1;
-  if (top === EdgeState.In && bottom === EdgeState.In) return VertexType.b2;
-  if (left === EdgeState.In && bottom === EdgeState.In) return VertexType.c1;
-  if (right === EdgeState.In && top === EdgeState.In) return VertexType.c2;
-
-  return null;
+  // Determine vertex type from the configuration. This MUST stay the exact
+  // inverse of getVertexConfiguration() below.
+  //   - both horizontal edges in  -> c1 (horizontal source/sink)
+  //   - both horizontal edges out -> c2 (vertical source/sink)
+  //   - otherwise exactly one horizontal edge is in (an a/b type), split by top
+  if (left === EdgeState.In && right === EdgeState.In) return VertexType.c1;
+  if (left === EdgeState.Out && right === EdgeState.Out) return VertexType.c2;
+  if (left === EdgeState.In) {
+    // left In, right Out
+    return top === EdgeState.In ? VertexType.a1 : VertexType.b2;
+  }
+  // left Out, right In
+  return top === EdgeState.In ? VertexType.b1 : VertexType.a2;
 }
 
 /**
@@ -306,31 +319,31 @@ export function getVertexConfiguration(type: VertexType): VertexConfiguration {
       };
     case VertexType.b1:
       return {
-        left: EdgeState.In,
         right: EdgeState.In,
-        top: EdgeState.Out,
+        top: EdgeState.In,
+        left: EdgeState.Out,
         bottom: EdgeState.Out,
       };
     case VertexType.b2:
       return {
-        top: EdgeState.In,
-        bottom: EdgeState.In,
-        left: EdgeState.Out,
-        right: EdgeState.Out,
-      };
-    case VertexType.c1:
-      return {
         left: EdgeState.In,
         bottom: EdgeState.In,
         right: EdgeState.Out,
         top: EdgeState.Out,
       };
+    case VertexType.c1:
+      return {
+        left: EdgeState.In,
+        right: EdgeState.In,
+        top: EdgeState.Out,
+        bottom: EdgeState.Out,
+      };
     case VertexType.c2:
       return {
-        right: EdgeState.In,
         top: EdgeState.In,
+        bottom: EdgeState.In,
         left: EdgeState.Out,
-        bottom: EdgeState.Out,
+        right: EdgeState.Out,
       };
   }
 }

--- a/client/src/lib/six-vertex/vertexShapes.ts
+++ b/client/src/lib/six-vertex/vertexShapes.ts
@@ -6,13 +6,14 @@
  * - Bold edges (thick lines) represent paths where arrows point in opposite directions
  * - Thin edges represent arrows pointing in the same direction
  *
- * Vertex type mappings from main.c:
- * - 0 = a1: arrows in from left & top, out to right & bottom
- * - 1 = a2: arrows in from right & bottom, out to left & top
- * - 2 = b1: arrows in from left & right, out to top & bottom
- * - 3 = b2: arrows in from top & bottom, out to left & right
- * - 4 = c1: arrows in from left & bottom, out to right & top
- * - 5 = c2: arrows in from right & top, out to left & bottom
+ * Vertex type mappings (arrow In/Out from the single source of truth,
+ * getVertexConfiguration in types.ts; numeric ids match main.c):
+ * - 0 = a1: in from left & top,     out to right & bottom
+ * - 1 = a2: in from right & bottom, out to left & top
+ * - 2 = b1: in from right & top,    out to left & bottom
+ * - 3 = b2: in from left & bottom,  out to right & top
+ * - 4 = c1: in from left & right,   out to top & bottom   (horizontal source/sink)
+ * - 5 = c2: in from top & bottom,   out to left & right   (vertical source/sink)
  */
 
 import { VertexType, EdgeDirection } from './types';
@@ -108,13 +109,13 @@ export function getVertexASCII(vertexType: VertexType): string[] {
     case VertexType.a2:
       return ['  ↑  ', '← ○ ←', '  ↑  '];
     case VertexType.b1:
-      return ['  ↑  ', '→ ○ →', '  ↓  '];
+      return ['  ↓  ', '← ○ ←', '  ↓  '];
     case VertexType.b2:
-      return ['  ↓  ', '← ○ ←', '  ↑  '];
+      return ['  ↑  ', '→ ○ →', '  ↑  '];
     case VertexType.c1:
-      return ['  ↑  ', '→ ○ ←', '  ↑  '];
+      return ['  ↑  ', '→ ○ ←', '  ↓  '];
     case VertexType.c2:
-      return ['  ↓  ', '→ ○ ←', '  ↓  '];
+      return ['  ↓  ', '← ○ →', '  ↑  '];
   }
 }
 

--- a/client/src/routes/dwbcVerify.tsx
+++ b/client/src/routes/dwbcVerify.tsx
@@ -7,6 +7,7 @@ import {
   generateDWBCHigh,
   generateDWBCLow,
   validateIceRule,
+  findEdgeInconsistencies,
 } from '../lib/six-vertex/initialStates';
 import { createRenderer, PathRenderer } from '../lib/six-vertex/renderer/pathRenderer';
 import { PhysicsSimulation } from '../lib/six-vertex/physicsSimulation';
@@ -161,69 +162,50 @@ export function DWBCVerify() {
     setShowPhysicsTest(true);
   };
 
-  const analyzeState = (state: LatticeState, type: 'high' | 'low') => {
+  // DWBC fixes the SAME boundary for both High and Low (they are the maximal and
+  // minimal height states inside that boundary): arrows point IN at the top and
+  // bottom, and OUT at the left and right. Count how many boundary edges match.
+  const analyzeState = (state: LatticeState) => {
     if (!state) return null;
 
-    // Analyze boundary arrows
-    const topIn = [];
-    const bottomOut = [];
-    const leftOut = [];
-    const rightIn = [];
+    let topIn = 0;
+    let bottomIn = 0;
+    let leftOut = 0;
+    let rightOut = 0;
 
-    // Check top boundary
     for (let col = 0; col < state.width; col++) {
-      const vertex = state.vertices[0][col];
-      if (vertex.configuration.top === 'out') {
-        topIn.push(col);
-      }
+      if (state.vertices[0][col].configuration.top === 'in') topIn++;
+      if (state.vertices[state.height - 1][col].configuration.bottom === 'in') bottomIn++;
     }
-
-    // Check bottom boundary
-    for (let col = 0; col < state.width; col++) {
-      const vertex = state.vertices[state.height - 1][col];
-      if (vertex.configuration.bottom === 'out') {
-        bottomOut.push(col);
-      }
-    }
-
-    // Check left boundary
     for (let row = 0; row < state.height; row++) {
-      const vertex = state.vertices[row][0];
-      if (vertex.configuration.left === 'in') {
-        leftOut.push(row);
-      }
-    }
-
-    // Check right boundary
-    for (let row = 0; row < state.height; row++) {
-      const vertex = state.vertices[row][state.width - 1];
-      if (vertex.configuration.right === 'out') {
-        rightIn.push(row);
-      }
+      if (state.vertices[row][0].configuration.left === 'out') leftOut++;
+      if (state.vertices[row][state.width - 1].configuration.right === 'out') rightOut++;
     }
 
     return {
-      topIn: topIn.length,
-      bottomOut: bottomOut.length,
-      leftOut: leftOut.length,
-      rightIn: rightIn.length,
-      expectedTop: type === 'high' ? state.width : 0,
-      expectedBottom: type === 'high' ? state.width : 0,
-      expectedLeft: type === 'high' ? state.height : 0,
-      expectedRight: type === 'high' ? state.height : 0,
+      topIn,
+      bottomIn,
+      leftOut,
+      rightOut,
+      expectedHorizontal: state.width,
+      expectedVertical: state.height,
+      inconsistencies: findEdgeInconsistencies(state).length,
     };
   };
 
-  const highAnalysis = highState ? analyzeState(highState, 'high') : null;
-  const lowAnalysis = lowState ? analyzeState(lowState, 'low') : null;
+  const highAnalysis = highState ? analyzeState(highState) : null;
+  const lowAnalysis = lowState ? analyzeState(lowState) : null;
 
   return (
     <PageShell title="DWBC Patterns" subtitle="The domain-wall boundary configurations">
       <div className="dwbc-verify">
         <p>
-          This tool verifies that Domain Wall Boundary Conditions are correctly implemented. High
-          DWBC should have arrows pointing in from top/right and out to bottom/left. Low DWBC should
-          have the opposite pattern.
+          This tool verifies that Domain Wall Boundary Conditions are correctly implemented. DWBC
+          fixes the <em>same</em> boundary for both High and Low (they are the maximal and minimal
+          height states within it): arrows point <strong>in</strong> at the top and bottom and{' '}
+          <strong>out</strong> at the left and right. High places its c₂ vertices on the
+          anti-diagonal; Low places them on the main diagonal. Every shared interior edge must carry
+          one consistent arrow (0 inconsistencies).
         </p>
 
         <div className="controls">
@@ -309,17 +291,18 @@ export function DWBCVerify() {
             {highAnalysis && (
               <div className="boundary-analysis">
                 <p>
-                  Top boundary (in): {highAnalysis.topIn}/{highAnalysis.expectedTop}
+                  Top boundary (in): {highAnalysis.topIn}/{highAnalysis.expectedHorizontal}
                 </p>
                 <p>
-                  Bottom boundary (out): {highAnalysis.bottomOut}/{highAnalysis.expectedBottom}
+                  Bottom boundary (in): {highAnalysis.bottomIn}/{highAnalysis.expectedHorizontal}
                 </p>
                 <p>
-                  Left boundary (out): {highAnalysis.leftOut}/{highAnalysis.expectedLeft}
+                  Left boundary (out): {highAnalysis.leftOut}/{highAnalysis.expectedVertical}
                 </p>
                 <p>
-                  Right boundary (in): {highAnalysis.rightIn}/{highAnalysis.expectedRight}
+                  Right boundary (out): {highAnalysis.rightOut}/{highAnalysis.expectedVertical}
                 </p>
+                <p>Edge inconsistencies: {highAnalysis.inconsistencies}</p>
               </div>
             )}
 
@@ -350,17 +333,18 @@ export function DWBCVerify() {
             {lowAnalysis && (
               <div className="boundary-analysis">
                 <p>
-                  Top boundary (out): {lowAnalysis.topIn}/{lowAnalysis.expectedTop}
+                  Top boundary (in): {lowAnalysis.topIn}/{lowAnalysis.expectedHorizontal}
                 </p>
                 <p>
-                  Bottom boundary (in): {lowAnalysis.bottomOut}/{lowAnalysis.expectedBottom}
+                  Bottom boundary (in): {lowAnalysis.bottomIn}/{lowAnalysis.expectedHorizontal}
                 </p>
                 <p>
-                  Left boundary (in): {lowAnalysis.leftOut}/{lowAnalysis.expectedLeft}
+                  Left boundary (out): {lowAnalysis.leftOut}/{lowAnalysis.expectedVertical}
                 </p>
                 <p>
-                  Right boundary (out): {lowAnalysis.rightIn}/{lowAnalysis.expectedRight}
+                  Right boundary (out): {lowAnalysis.rightOut}/{lowAnalysis.expectedVertical}
                 </p>
+                <p>Edge inconsistencies: {lowAnalysis.inconsistencies}</p>
               </div>
             )}
 

--- a/client/tests/heightFunction.test.ts
+++ b/client/tests/heightFunction.test.ts
@@ -181,9 +181,9 @@ describe('Height Function Calculator', () => {
 
       const contribution = getVertexHeightContribution(vertex);
 
-      // b1 has In from left and right, Out to top and bottom
-      expect(contribution.fromLeft).toBe(1);
-      expect(contribution.fromTop).toBe(0);
+      // b1 has In from right and top, Out to left and bottom (Fig. 1)
+      expect(contribution.fromLeft).toBe(0);
+      expect(contribution.fromTop).toBe(1);
       expect(contribution.total).toBe(1);
     });
   });

--- a/client/tests/six-vertex/edgeConsistency.test.ts
+++ b/client/tests/six-vertex/edgeConsistency.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Edge-consistency & arrow-convention tests for the 6-vertex model.
+ *
+ * These lock in the canonical arrow table (Fig. 1 of arXiv:cond-mat/0502314v1)
+ * via three independent checks that together pin it uniquely:
+ *   1. getVertexConfiguration matches the verified table and getVertexType is its
+ *      exact inverse;
+ *   2. the DWBC High/Low grids (both the object generators and the optimized
+ *      engine's id grids) are edge-consistent and have the correct fixed
+ *      boundary; and
+ *   3. the thick-edge set implied by the arrows (arrow points down or right)
+ *      matches the bold path segments (getPathSegments / main.c draw_vertex).
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import type { LatticeState, Vertex } from '../../src/lib/six-vertex/types';
+import {
+  VertexType,
+  EdgeState,
+  EdgeDirection,
+  getVertexConfiguration,
+  getVertexType,
+} from '../../src/lib/six-vertex/types';
+import {
+  generateDWBCHigh,
+  generateDWBCLow,
+  validateIceRule,
+  validateEdgeConsistency,
+  findEdgeInconsistencies,
+} from '../../src/lib/six-vertex/initialStates';
+import {
+  generateDWBCHighOptimized,
+  generateDWBCLowOptimized,
+} from '../../src/lib/six-vertex/optimizedSimulation';
+import { getPathSegments } from '../../src/lib/six-vertex/vertexShapes';
+
+const { In, Out } = EdgeState;
+
+// The canonical table (left, right, top, bottom), verified three independent ways.
+const CANONICAL: Record<VertexType, [EdgeState, EdgeState, EdgeState, EdgeState]> = {
+  [VertexType.a1]: [In, Out, In, Out],
+  [VertexType.a2]: [Out, In, Out, In],
+  [VertexType.b1]: [Out, In, In, Out],
+  [VertexType.b2]: [In, Out, Out, In],
+  [VertexType.c1]: [In, In, Out, Out],
+  [VertexType.c2]: [Out, Out, In, In],
+};
+
+const ALL_TYPES = Object.values(VertexType);
+const NUM_TO_TYPE = [
+  VertexType.a1,
+  VertexType.a2,
+  VertexType.b1,
+  VertexType.b2,
+  VertexType.c1,
+  VertexType.c2,
+];
+
+function rawToState(raw: Int8Array | Uint8Array, size: number): LatticeState {
+  const vertices: Vertex[][] = [];
+  for (let row = 0; row < size; row++) {
+    vertices[row] = [];
+    for (let col = 0; col < size; col++) {
+      const type = NUM_TO_TYPE[raw[row * size + col]];
+      vertices[row][col] = {
+        position: { row, col },
+        type,
+        configuration: getVertexConfiguration(type),
+      };
+    }
+  }
+  return { width: size, height: size, vertices, horizontalEdges: [], verticalEdges: [] };
+}
+
+describe('Canonical arrow table', () => {
+  it('getVertexConfiguration matches the verified table', () => {
+    for (const type of ALL_TYPES) {
+      const cfg = getVertexConfiguration(type);
+      const [left, right, top, bottom] = CANONICAL[type];
+      expect({ ...cfg }).toEqual({ left, right, top, bottom });
+    }
+  });
+
+  it('every type is a valid 2-in / 2-out ice configuration', () => {
+    for (const type of ALL_TYPES) {
+      const cfg = getVertexConfiguration(type);
+      const ins = [cfg.left, cfg.right, cfg.top, cfg.bottom].filter((e) => e === In).length;
+      expect(ins).toBe(2);
+    }
+  });
+
+  it('getVertexType is the exact inverse of getVertexConfiguration', () => {
+    for (const type of ALL_TYPES) {
+      expect(getVertexType(getVertexConfiguration(type))).toBe(type);
+    }
+  });
+
+  it('a1 and a2 are unchanged (already correct before the fix)', () => {
+    expect({ ...getVertexConfiguration(VertexType.a1) }).toEqual({
+      left: In,
+      right: Out,
+      top: In,
+      bottom: Out,
+    });
+    expect({ ...getVertexConfiguration(VertexType.a2) }).toEqual({
+      left: Out,
+      right: In,
+      top: Out,
+      bottom: In,
+    });
+  });
+});
+
+describe('Arrows agree with the bold path picture (main.c draw_vertex)', () => {
+  // An edge is thick iff its arrow points down or right:
+  //   left In, right Out, top In, bottom Out.
+  function thickFromArrows(type: VertexType): Set<EdgeDirection> {
+    const c = getVertexConfiguration(type);
+    const s = new Set<EdgeDirection>();
+    if (c.left === In) s.add(EdgeDirection.Left);
+    if (c.right === Out) s.add(EdgeDirection.Right);
+    if (c.top === In) s.add(EdgeDirection.Top);
+    if (c.bottom === Out) s.add(EdgeDirection.Bottom);
+    return s;
+  }
+  function thickFromPaths(type: VertexType): Set<EdgeDirection> {
+    const s = new Set<EdgeDirection>();
+    for (const seg of getPathSegments(type)) {
+      s.add(seg.from);
+      s.add(seg.to);
+    }
+    return s;
+  }
+
+  it('thick-edge set from arrows equals bold path segments for every type', () => {
+    for (const type of ALL_TYPES) {
+      expect([...thickFromArrows(type)].sort()).toEqual([...thickFromPaths(type)].sort());
+    }
+  });
+});
+
+describe('DWBC grids are edge-consistent (object generators)', () => {
+  const sizes = [4, 6, 8, 24];
+
+  for (const size of sizes) {
+    it(`DWBC High (N=${size}) is ice-valid and edge-consistent`, () => {
+      const state = generateDWBCHigh(size);
+      expect(validateIceRule(state)).toBe(true);
+      expect(findEdgeInconsistencies(state)).toHaveLength(0);
+      expect(validateEdgeConsistency(state)).toBe(true);
+    });
+
+    it(`DWBC Low (N=${size}) is ice-valid and edge-consistent`, () => {
+      const state = generateDWBCLow(size);
+      expect(validateIceRule(state)).toBe(true);
+      expect(findEdgeInconsistencies(state)).toHaveLength(0);
+      expect(validateEdgeConsistency(state)).toBe(true);
+    });
+  }
+
+  it('High and Low share the same fixed boundary: in top/bottom, out left/right', () => {
+    for (const state of [generateDWBCHigh(8), generateDWBCLow(8)]) {
+      const n = state.width;
+      for (let col = 0; col < n; col++) {
+        expect(state.vertices[0][col].configuration.top).toBe(In);
+        expect(state.vertices[n - 1][col].configuration.bottom).toBe(In);
+      }
+      for (let row = 0; row < n; row++) {
+        expect(state.vertices[row][0].configuration.left).toBe(Out);
+        expect(state.vertices[row][n - 1].configuration.right).toBe(Out);
+      }
+    }
+  });
+});
+
+describe('DWBC grids are edge-consistent (optimized engine id grids)', () => {
+  const sizes = [4, 6, 8, 24];
+  for (const size of sizes) {
+    it(`optimized DWBC High (N=${size}) maps to an edge-consistent state`, () => {
+      const state = rawToState(generateDWBCHighOptimized(size), size);
+      expect(findEdgeInconsistencies(state)).toHaveLength(0);
+    });
+    it(`optimized DWBC Low (N=${size}) maps to an edge-consistent state`, () => {
+      const state = rawToState(generateDWBCLowOptimized(size), size);
+      expect(findEdgeInconsistencies(state)).toHaveLength(0);
+    });
+  }
+});
+
+describe('findEdgeInconsistencies actually detects breakage', () => {
+  it('flags a deliberately corrupted vertex', () => {
+    const state = generateDWBCHigh(6);
+    // Force a mismatch: make an interior vertex disagree with its right neighbour.
+    const v = state.vertices[2][2];
+    v.configuration = { ...v.configuration, right: v.configuration.right === In ? Out : In };
+    expect(findEdgeInconsistencies(state).length).toBeGreaterThan(0);
+  });
+});

--- a/client/tests/six-vertex/heatBath.test.ts
+++ b/client/tests/six-vertex/heatBath.test.ts
@@ -10,7 +10,12 @@ import {
   isFlippable,
   getAllFlippablePositions,
 } from '../../src/lib/six-vertex/physicsFlips';
-import { generateDWBCLow, generateRandomIceState } from '../../src/lib/six-vertex/initialStates';
+import {
+  generateDWBCLow,
+  generateRandomIceState,
+  validateIceRule,
+  findEdgeInconsistencies,
+} from '../../src/lib/six-vertex/initialStates';
 import { VertexType } from '../../src/lib/six-vertex/types';
 import { SeededRNG } from '../../src/lib/six-vertex/rng';
 
@@ -233,12 +238,12 @@ describe('Heat-Bath Probability Tests', () => {
         [VertexType.c2]: 1,
       };
 
-      // NOTE: the initial-state seed must yield a configuration with at least
-      // one flippable plaquette, otherwise the Markov chain is frozen and only
-      // a single vertex type is ever observed. Seed 54321 produces an all-a1
-      // uniform state on a 3x3 lattice (zero flippable positions); seed 1 gives
-      // a genuinely flippable starting configuration so the chain actually mixes.
-      let state = generateRandomIceState(3, 3, 1);
+      // Use an 8x8 lattice: it mixes freely under the local flip dynamics, so all
+      // six vertex types are visited with comparable frequency. (A 3x3 lattice is
+      // too small — its flip-connected sector can exclude a type entirely, which
+      // is a finite-size artefact, not a convergence failure.)
+      const N = 8;
+      let state = generateRandomIceState(N, N, 1);
       const vertexCounts = new Map<VertexType, number>();
 
       // Run simulation for many steps
@@ -281,8 +286,12 @@ describe('Heat-Bath Probability Tests', () => {
 
         // Count vertex types after burn-in
         if (step >= burnIn) {
-          for (let row = 0; row < 3; row++) {
-            for (let col = 0; col < 3; col++) {
+          // Every visited state must remain a valid, edge-consistent ice state:
+          // the flip dynamics must never corrupt the lattice.
+          expect(validateIceRule(state)).toBe(true);
+          expect(findEdgeInconsistencies(state)).toHaveLength(0);
+          for (let row = 0; row < N; row++) {
+            for (let col = 0; col < N; col++) {
               const type = state.vertices[row][col].type;
               vertexCounts.set(type, (vertexCounts.get(type) || 0) + 1);
             }
@@ -290,18 +299,16 @@ describe('Heat-Bath Probability Tests', () => {
         }
       }
 
-      // With equal weights, all vertex types should appear with similar frequency
-      // (though not exactly equal due to ice rule constraints)
+      // With equal weights, all six vertex types should appear with comparable
+      // frequency (though not exactly equal due to ice-rule / boundary effects).
       const totalCounts = Array.from(vertexCounts.values()).reduce((a, b) => a + b, 0);
 
-      // Guard: the chain must actually mix. A frozen initial state would only
-      // ever show one vertex type, which would make the frequency bounds below
-      // vacuously (or never) satisfiable. Require genuine diversity.
-      expect(vertexCounts.size).toBeGreaterThan(1);
+      // The chain must mix across all six types, not sit in a frozen sector.
+      expect(vertexCounts.size).toBe(6);
 
       for (const count of vertexCounts.values()) {
         const frequency = count / totalCounts;
-        // Should be roughly 1/6 ≈ 0.167, but with significant variance
+        // Should be roughly 1/6 ≈ 0.167, but with significant variance.
         expect(frequency).toBeGreaterThan(0.05);
         expect(frequency).toBeLessThan(0.5);
       }

--- a/client/tests/six-vertex/initialStates.test.ts
+++ b/client/tests/six-vertex/initialStates.test.ts
@@ -87,24 +87,16 @@ describe('Initial States - DWBC Pattern Tests', () => {
     it('should have correct boundary conditions', () => {
       const state = generateDWBCHigh(8);
 
-      // Top boundary: all arrows point down (into lattice)
+      // DWBC fixes the same boundary for High and Low (checked via the canonical
+      // per-vertex configuration, the source of truth): arrows point IN at the
+      // top and bottom, OUT at the left and right.
       for (let col = 0; col < 8; col++) {
-        expect(state.verticalEdges[0][col]).toBe(EdgeState.In);
+        expect(state.vertices[0][col].configuration.top).toBe(EdgeState.In);
+        expect(state.vertices[7][col].configuration.bottom).toBe(EdgeState.In);
       }
-
-      // Bottom boundary: all arrows point down (out of lattice)
-      for (let col = 0; col < 8; col++) {
-        expect(state.verticalEdges[8][col]).toBe(EdgeState.Out);
-      }
-
-      // Left boundary: all arrows point right (into lattice)
       for (let row = 0; row < 8; row++) {
-        expect(state.horizontalEdges[row][0]).toBe(EdgeState.Out);
-      }
-
-      // Right boundary: all arrows point right (out of lattice)
-      for (let row = 0; row < 8; row++) {
-        expect(state.horizontalEdges[row][8]).toBe(EdgeState.In);
+        expect(state.vertices[row][0].configuration.left).toBe(EdgeState.Out);
+        expect(state.vertices[row][7].configuration.right).toBe(EdgeState.Out);
       }
     });
 
@@ -187,24 +179,16 @@ describe('Initial States - DWBC Pattern Tests', () => {
     it('should have correct boundary conditions', () => {
       const state = generateDWBCLow(8);
 
-      // Top boundary: all arrows point up (out of lattice)
+      // DWBC Low has the SAME fixed boundary as High (it is the minimal height
+      // state within it): arrows IN at top/bottom, OUT at left/right. Verified
+      // via the canonical per-vertex configuration.
       for (let col = 0; col < 8; col++) {
-        expect(state.verticalEdges[0][col]).toBe(EdgeState.Out);
+        expect(state.vertices[0][col].configuration.top).toBe(EdgeState.In);
+        expect(state.vertices[7][col].configuration.bottom).toBe(EdgeState.In);
       }
-
-      // Bottom boundary: all arrows point up (into lattice)
-      for (let col = 0; col < 8; col++) {
-        expect(state.verticalEdges[8][col]).toBe(EdgeState.In);
-      }
-
-      // Left boundary: all arrows point left (into boundary)
       for (let row = 0; row < 8; row++) {
-        expect(state.horizontalEdges[row][0]).toBe(EdgeState.In);
-      }
-
-      // Right boundary: all arrows point left (out of boundary)
-      for (let row = 0; row < 8; row++) {
-        expect(state.horizontalEdges[row][8]).toBe(EdgeState.Out);
+        expect(state.vertices[row][0].configuration.left).toBe(EdgeState.Out);
+        expect(state.vertices[row][7].configuration.right).toBe(EdgeState.Out);
       }
     });
 

--- a/client/tests/six-vertex/types.test.ts
+++ b/client/tests/six-vertex/types.test.ts
@@ -30,9 +30,9 @@ describe('6-Vertex Model Types', () => {
 
     it('should correctly identify vertex type b1', () => {
       const config: VertexConfiguration = {
-        left: EdgeState.In,
         right: EdgeState.In,
-        top: EdgeState.Out,
+        top: EdgeState.In,
+        left: EdgeState.Out,
         bottom: EdgeState.Out,
       };
       expect(getVertexType(config)).toBe(VertexType.b1);
@@ -40,10 +40,10 @@ describe('6-Vertex Model Types', () => {
 
     it('should correctly identify vertex type b2', () => {
       const config: VertexConfiguration = {
-        top: EdgeState.In,
+        left: EdgeState.In,
         bottom: EdgeState.In,
-        left: EdgeState.Out,
         right: EdgeState.Out,
+        top: EdgeState.Out,
       };
       expect(getVertexType(config)).toBe(VertexType.b2);
     });
@@ -51,19 +51,19 @@ describe('6-Vertex Model Types', () => {
     it('should correctly identify vertex type c1', () => {
       const config: VertexConfiguration = {
         left: EdgeState.In,
-        bottom: EdgeState.In,
-        right: EdgeState.Out,
+        right: EdgeState.In,
         top: EdgeState.Out,
+        bottom: EdgeState.Out,
       };
       expect(getVertexType(config)).toBe(VertexType.c1);
     });
 
     it('should correctly identify vertex type c2', () => {
       const config: VertexConfiguration = {
-        right: EdgeState.In,
         top: EdgeState.In,
+        bottom: EdgeState.In,
         left: EdgeState.Out,
-        bottom: EdgeState.Out,
+        right: EdgeState.Out,
       };
       expect(getVertexType(config)).toBe(VertexType.c2);
     });


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-79.dev.6v.allison.la

## Summary
The arrow In/Out labels in `getVertexConfiguration` were wrong for **b1, b2, c1, c2** (a1/a2 were already correct). On the paper-verified DWBC grids this produced **40/60** inconsistent shared edges for High and **10/60** for Low — breaking the Arrows/Both overlay and the `/dwbc-verify` boundary check. The mislabel also **swapped the b and c configurations** (e.g. the both-horizontal-in source/sink — physically a c-vertex — was labelled `b1`), so the small-lattice (N≤8) config-based engine applied the wrong b/c weights when weights were non-uniform. The optimized engine (N>8, type-ID based) was unaffected.

This was researched against the literature (Allison–Reshetikhin arXiv:cond-mat/0502314 Fig. 1, Reshetikhin arXiv:1010.5011, Baxter ch. 8) and `main.c`, then pinned uniquely.

## The canonical table (verified three independent ways)
All three agree — encoded in `tests/six-vertex/edgeConsistency.test.ts`:
1. **Unique edge-consistent assignment** on both DWBC grids — brute force finds exactly two solutions (global arrow reversals); only one matches the rest. 0/60 violations on High and Low.
2. **Thick-edge set** (arrow points down or right) matches `main.c` `draw_vertex` for every vertex.
3. **DWBC boundary** becomes "in at top/bottom, out at left/right" (matches Reshetikhin arXiv:1010.5011).

| type | left | right | top | bottom | |
|------|------|-------|-----|--------|--|
| a1 | In | Out | In | Out | unchanged |
| a2 | Out | In | Out | In | unchanged |
| b1 | Out | In | In | Out | fixed |
| b2 | In | Out | Out | In | fixed |
| c1 | In | In | Out | Out | fixed |
| c2 | Out | Out | In | In | fixed |

| metric | before | after |
|---|---|---|
| DWBC-High interior edge violations | 40/60 | **0/60** |
| DWBC-Low interior edge violations | 10/60 | **0/60** |

## Changes
- **types.ts** — canonical `getVertexConfiguration` + matching inverse `getVertexType` (single source of truth).
- **dwbcCorrectIce.ts / optimizedSimulation.ts** — delegate to the source of truth; DWBC edge arrays fully derived from configs (no more partial/buggy fill); guard invalid sizes.
- **vertexShapes.ts** — fix `getVertexASCII` + header comment (`getPathSegments` / Paths mode was already correct).
- **initialStates.ts** — add `findEdgeInconsistencies` / `validateEdgeConsistency`: a real neighbour-consistency validator (the old `validateIceRule` only checked each vertex in isolation — the audit-flagged "vacuous validator").
- **/dwbc-verify route** — report real edge inconsistencies and the correct shared boundary for both High and Low (previously claimed Low had the opposite boundary, a misconception).
- **tests** — new `edgeConsistency` suite (triple validation + dynamics preserve edge consistency); update type/height/boundary tests to the canonical table; move the heat-bath convergence test to 8×8 (3×3 is too small — its flip-connected sector can exclude a vertex type) and assert ice + edge consistency on every step.

## Testing
- [x] Full suite green (381 passed)
- [x] `tsc --noEmit` clean, ESLint clean (only pre-existing `any` warnings), `vite build` clean
- [x] In-browser `/dwbc-verify`: both High & Low show Ice Rule Valid, boundary 8/8 on all sides, **Edge inconsistencies: 0**; Both mode shows arrows flowing consistently along the bold paths (High = anti-diagonal staircase per Fig. 2, Low = upper-left region per Fig. 3)
- [x] Verified the optimized engine's id grids also map to edge-consistent states under the canonical table

## Related Issues
Fixes #77
