### PR TITLE
perf: collapse N-sim per-frame getStats sweeps and throttle UI publishing (#69)

### DIFF
--- a/client/src/lib/six-vertex/nSimulation.ts
+++ b/client/src/lib/six-vertex/nSimulation.ts
@@ -155,9 +155,13 @@ export class NSimulationManager {
     });
   }
 
-  /** Append the current observables to each instance's history (capped). */
-  pushHistory(): void {
-    const snapshots = this.getSnapshots();
+  /**
+   * Append the current observables to each instance's history (capped).
+   * Accepts pre-computed snapshots so a caller already holding them (e.g. the
+   * render loop) doesn't trigger another full getStats() sweep. Returns the
+   * snapshots used, so the caller can reuse them for readouts + stop checks.
+   */
+  pushHistory(snapshots: NSimSnapshot[] = this.getSnapshots()): NSimSnapshot[] {
     for (let i = 0; i < snapshots.length; i++) {
       if (!this.history[i]) this.history[i] = [];
       const series = this.history[i];
@@ -166,6 +170,7 @@ export class NSimulationManager {
         series.shift();
       }
     }
+    return snapshots;
   }
 
   /** Copy of the per-instance observable history (oldest -> newest). */
@@ -174,26 +179,25 @@ export class NSimulationManager {
   }
 
   /** Current cross-instance relative spread (the live convergence readout). */
-  getRelativeSpread(): number {
-    const observables = this.getSnapshots().map((s) => s.observable);
-    return relativeSpread(observables);
+  getRelativeSpread(snapshots: NSimSnapshot[] = this.getSnapshots()): number {
+    return relativeSpread(snapshots.map((s) => s.observable));
   }
 
   /** Max step across instances (used as the global step for stop conditions). */
-  getStep(): number {
-    return this.getSnapshots().reduce((max, s) => Math.max(max, s.step), 0);
+  getStep(snapshots: NSimSnapshot[] = this.getSnapshots()): number {
+    return snapshots.reduce((max, s) => Math.max(max, s.step), 0);
   }
 
-  private buildStopContext(): StopContext {
+  private buildStopContext(snapshots: NSimSnapshot[]): StopContext {
     return {
-      step: this.getStep(),
-      instances: this.getSnapshots(),
+      step: this.getStep(snapshots),
+      instances: snapshots,
       history: this.history,
     };
   }
 
   /** Evaluate a stop predicate against the current snapshots + history. */
-  evaluateStop(predicate: StopPredicate): boolean {
-    return predicate(this.buildStopContext());
+  evaluateStop(predicate: StopPredicate, snapshots: NSimSnapshot[] = this.getSnapshots()): boolean {
+    return predicate(this.buildStopContext(snapshots));
   }
 }

--- a/client/src/routes/nSimulation.tsx
+++ b/client/src/routes/nSimulation.tsx
@@ -201,6 +201,11 @@ export function NSimulation() {
   const animationFrameRef = useRef<number | null>(null);
   const isRunningRef = useRef(false);
   isRunningRef.current = isRunning;
+  // Throttle React state updates (chart + readout re-renders) to ~10 Hz. The MC
+  // loop still steps every animation frame; only the UI publish cadence is
+  // capped, so a long run doesn't re-render the whole route 60×/s.
+  const lastPublishRef = useRef(0);
+  const PUBLISH_INTERVAL_MS = 100;
 
   // Build the active stop predicate from the current selection.
   const stopPredicate = useMemo<StopPredicate>(() => {
@@ -220,12 +225,21 @@ export function NSimulation() {
   const stopPredicateRef = useRef(stopPredicate);
   stopPredicateRef.current = stopPredicate;
 
+  // Publish readouts from a single snapshot sweep. Pass pre-computed snapshots
+  // (from the tick) to avoid a second getStats() pass; omit for one-shot callers.
+  const publishReadouts = useCallback(
+    (manager: NSimulationManager, snaps = manager.getSnapshots()) => {
+      setSpread(manager.getRelativeSpread(snaps));
+      setSnapshots(snaps.map((s) => s.stats));
+    },
+    [],
+  );
+
   const refreshReadouts = useCallback(() => {
     const manager = managerRef.current;
     if (!manager) return;
-    setSpread(manager.getRelativeSpread());
-    setSnapshots(manager.getSnapshots().map((s) => s.stats));
-  }, []);
+    publishReadouts(manager);
+  }, [publishReadouts]);
 
   // Build (or rebuild) the manager from the current draft config.
   const applyConfig = useCallback(() => {
@@ -250,9 +264,8 @@ export function NSimulation() {
     setControllers(manager.getControllers());
     setActiveInstances(manager.getInstanceConfigs());
     setIsLargeActive(manager.isLarge());
-    setSpread(manager.getRelativeSpread());
-    setSnapshots(manager.getSnapshots().map((s) => s.stats));
-  }, [size, temperature, weights, instances]);
+    publishReadouts(manager);
+  }, [size, temperature, weights, instances, publishReadouts]);
 
   // Build on mount and dispose on unmount (terminating workers).
   useEffect(() => {
@@ -281,18 +294,26 @@ export function NSimulation() {
       }
     }
 
-    manager.pushHistory();
-    refreshReadouts();
+    // One snapshot sweep per frame, reused for history, stop check and readouts.
+    const snaps = manager.pushHistory();
 
-    if (manager.evaluateStop(stopPredicateRef.current)) {
-      setConvergedAtStep(manager.getStep());
+    if (manager.evaluateStop(stopPredicateRef.current, snaps)) {
+      publishReadouts(manager, snaps); // always publish the final state
+      setConvergedAtStep(manager.getStep(snaps));
       setIsRunning(false);
       manager.pause();
       return;
     }
 
+    // Throttle UI publishing; the simulation itself keeps stepping every frame.
+    const now = performance.now();
+    if (now - lastPublishRef.current >= PUBLISH_INTERVAL_MS) {
+      lastPublishRef.current = now;
+      publishReadouts(manager, snaps);
+    }
+
     animationFrameRef.current = requestAnimationFrame(tick);
-  }, [stepsPerFrame, refreshReadouts]);
+  }, [stepsPerFrame, publishReadouts]);
 
   // Start/stop the run loop.
   useEffect(() => {
@@ -300,6 +321,7 @@ export function NSimulation() {
     if (!manager) return;
     if (isRunning) {
       setConvergedAtStep(null);
+      lastPublishRef.current = 0; // publish on the very first frame of the run
       if (manager.isLarge()) {
         manager.run();
       }

--- a/client/tests/six-vertex/nSimulationManager.test.ts
+++ b/client/tests/six-vertex/nSimulationManager.test.ts
@@ -1,0 +1,96 @@
+/**
+ * NSimulationManager: the snapshot-reuse contract behind the N-sim tick perf fix.
+ *
+ * pushHistory / getRelativeSpread / getStep / evaluateStop all accept a
+ * pre-computed snapshot array so the render loop can sweep getStats() ONCE per
+ * frame instead of ~5×. These tests pin that the optional-arg results match the
+ * compute-internally results, and that reusing snapshots really does avoid the
+ * extra getStats() passes.
+ */
+
+// simulation.ts transitively imports the worker interface, whose real source
+// uses `new Worker(new URL(..., import.meta.url))` — ts-jest (CommonJS) can't
+// parse that. A factory mock means the real file is never evaluated. These
+// tests use small (size=6) synchronous lattices, so the worker is never used.
+jest.mock('../../src/lib/six-vertex/worker/workerInterface', () => ({
+  isWorkerSupported: () => false,
+  WorkerSimulation: class {},
+  createWorkerSimulation: jest.fn(),
+}));
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { NSimulationManager } from '../../src/lib/six-vertex/nSimulation';
+import type { NSimConfig } from '../../src/lib/six-vertex/nSimulation';
+import { manual, maxSteps } from '../../src/lib/six-vertex/stopConditions';
+
+function makeManager(): NSimulationManager {
+  const config: NSimConfig = {
+    size: 6, // small -> synchronous optimized engine, no worker
+    temperature: 1.0,
+    weights: { a1: 1, a2: 1, b1: 1, b2: 1, c1: 1, c2: 1 },
+    instances: [
+      { id: 'a', label: 'A', initialState: 'dwbc-high', seed: 1 },
+      { id: 'b', label: 'B', initialState: 'dwbc-low', seed: 2 },
+      { id: 'c', label: 'C', initialState: 'random', seed: 3 },
+    ],
+  };
+  return new NSimulationManager(config);
+}
+
+describe('NSimulationManager snapshot reuse', () => {
+  it('pushHistory returns the snapshots it used and appends one sample per instance', () => {
+    const m = makeManager();
+    const snaps = m.pushHistory();
+    expect(snaps).toHaveLength(3);
+    expect(m.getHistory().map((s) => s.length)).toEqual([1, 1, 1]);
+
+    // Passing snapshots back in appends another sample without recomputing.
+    m.pushHistory(snaps);
+    expect(m.getHistory().map((s) => s.length)).toEqual([2, 2, 2]);
+  });
+
+  it('getRelativeSpread / getStep give the same answer with or without passed snapshots', () => {
+    const m = makeManager();
+    const snaps = m.getSnapshots();
+    expect(m.getRelativeSpread(snaps)).toBe(m.getRelativeSpread());
+    expect(m.getStep(snaps)).toBe(m.getStep());
+  });
+
+  it('evaluateStop gives the same verdict with or without passed snapshots', () => {
+    const m = makeManager();
+    const snaps = m.getSnapshots();
+    // manual() never stops; maxSteps(0) stops immediately — both convention-independent.
+    expect(m.evaluateStop(manual().predicate, snaps)).toBe(m.evaluateStop(manual().predicate));
+    expect(m.evaluateStop(maxSteps(0).predicate, snaps)).toBe(true);
+  });
+
+  it('reusing one snapshot sweep calls getStats exactly once per instance', () => {
+    const m = makeManager();
+    const spies = m.getControllers().map((c) => jest.spyOn(c, 'getStats'));
+
+    // The render-loop pattern: sweep once, then reuse everywhere.
+    const snaps = m.getSnapshots();
+    m.pushHistory(snaps);
+    m.getRelativeSpread(snaps);
+    m.getStep(snaps);
+    m.evaluateStop(maxSteps(1_000_000).predicate, snaps);
+
+    for (const spy of spies) {
+      expect(spy).toHaveBeenCalledTimes(1); // the single getSnapshots() sweep
+    }
+  });
+
+  it('NOT reusing snapshots costs multiple getStats sweeps (documents the old hot path)', () => {
+    const m = makeManager();
+    const spies = m.getControllers().map((c) => jest.spyOn(c, 'getStats'));
+
+    m.pushHistory(); // sweep 1
+    m.getRelativeSpread(); // sweep 2
+    m.getStep(); // sweep 3
+    m.evaluateStop(maxSteps(1_000_000).predicate); // sweep 4 (+ getStep inside -> 5)
+
+    for (const spy of spies) {
+      expect(spy.mock.calls.length).toBeGreaterThan(1);
+    }
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-80.dev.6v.allison.la

## Summary
The `/n-simulation` rAF tick swept `getStats()` across every instance **~5× per frame** (once each in `pushHistory`, `getRelativeSpread`, `setSnapshots`, plus twice inside `evaluateStop` via `getStep` + the stop context) and pushed React state at the full **60 Hz**, so a long multi-instance run re-rendered the whole route (charts included) every frame. This is the N-sim tick-efficiency item from the #63 adversarial audit (#69).

## Changes
- **`nSimulation.ts`** — `pushHistory` / `getRelativeSpread` / `getStep` / `evaluateStop` now accept an optional pre-computed snapshot array (default `= getSnapshots()`), and `pushHistory` returns the snapshots it used. Backward compatible.
- **`nSimulation.tsx`** — the tick takes **one** snapshot sweep per frame and threads it through history, the stop check, and readouts → one `getStats()` pass per instance per frame instead of ~5. UI publishing (`setSnapshots`/`setSpread`) is **throttled to ~10 Hz** while the MC loop keeps stepping every frame; the final state is always published on stop, and the publish timer resets on run start.
- **New `nSimulationManager` test suite** — asserts the optional-arg results equal the compute-internally results, and that reusing one sweep calls `getStats` **exactly once per instance** (vs >1 without).

No change to simulation trajectories or stop semantics — purely the sampling/render cadence.

## Testing
- [x] Full suite green (381 → **386**)
- [x] `tsc --noEmit` clean, ESLint clean, `vite build` clean
- [x] In-browser `/n-simulation`: runs smoothly, the Relative-spread readout updates live and converges (2.67% → 0.00%), charts render, console clean

## Related Issues
Refs #69
