### PR TITLE
feat: shareable config via URL (#60)

### DIFF
--- a/client/src/MainSimulator.tsx
+++ b/client/src/MainSimulator.tsx
@@ -16,6 +16,8 @@ import StatisticsPanel from './components/StatisticsPanel';
 import { anisotropyDelta } from './lib/six-vertex/observables';
 import VisualizationCanvas from './components/VisualizationCanvas';
 import { SaveLoadPanel } from './components/SaveLoadPanel';
+import { ShareConfigButton } from './components/ShareConfigButton';
+import { readConfigFromSearch } from './lib/six-vertex/configUrl';
 import { CollapsiblePanel } from './components/CollapsiblePanel';
 import IntroPanel from './components/IntroPanel';
 import PresetBar from './components/PresetBar';
@@ -23,6 +25,11 @@ import type { PresetConfig } from './components/PresetBar';
 import type { SimulationData } from './lib/storage';
 import { useTheme } from './hooks/useTheme';
 import { getThemeColors } from './lib/six-vertex/themeColors';
+
+// Decode a shareable config from the page URL once at module load, so the state
+// initializers below can seed from a shared link (issue #60). Invalid/absent
+// params fall through to the defaults.
+const urlConfig = readConfigFromSearch(typeof window !== 'undefined' ? window.location.search : '');
 
 function MainSimulator() {
   // Get theme context
@@ -41,9 +48,9 @@ function MainSimulator() {
   const [latticeState, setLatticeState] = useState<LatticeState | null>(null);
   // Compact typed-array state used for large lattices (avoids ~N*N object churn).
   const [rawState, setRawState] = useState<RawLatticeState | null>(null);
-  const [latticeSize, setLatticeSize] = useState(10);
+  const [latticeSize, setLatticeSize] = useState(() => urlConfig.latticeSize ?? 10);
   const [fps, setFps] = useState(0);
-  const [stepsPerFrame, setStepsPerFrame] = useState(10);
+  const [stepsPerFrame, setStepsPerFrame] = useState(() => urlConfig.stepsPerFrame ?? 10);
 
   // Large lattices render from the raw typed array rather than the object form.
   const isLarge = latticeSize > LARGE_LATTICE_THRESHOLD;
@@ -72,25 +79,30 @@ function MainSimulator() {
   rawStateRef.current = rawState;
 
   // Simulation parameters
-  const [temperature, setTemperature] = useState(1.0);
+  const [temperature, setTemperature] = useState(() => urlConfig.temperature ?? 1.0);
   const [boundaryCondition, setBoundaryCondition] = useState<BoundaryCondition>(
-    BoundaryCondition.DWBC,
+    () => urlConfig.boundaryCondition ?? BoundaryCondition.DWBC,
   );
-  const [dwbcType, setDwbcType] = useState<'high' | 'low'>('high');
-  const [renderMode, setRenderMode] = useState<RenderMode>(RenderMode.Paths);
-  const [showGrid, setShowGrid] = useState(true);
-  const [animateFlips, setAnimateFlips] = useState(false);
-  const [seed, setSeed] = useState(12345);
+  const [dwbcType, setDwbcType] = useState<'high' | 'low'>(() => urlConfig.dwbcType ?? 'high');
+  const [renderMode, setRenderMode] = useState<RenderMode>(
+    () => urlConfig.renderMode ?? RenderMode.Paths,
+  );
+  const [showGrid, setShowGrid] = useState(() => urlConfig.showGrid ?? true);
+  const [animateFlips, setAnimateFlips] = useState(() => urlConfig.animateFlips ?? false);
+  const [seed, setSeed] = useState(() => urlConfig.seed ?? 12345);
 
   // Vertex weights
-  const [weights, setWeights] = useState({
-    a1: 1.0,
-    a2: 1.0,
-    b1: 1.0,
-    b2: 1.0,
-    c1: 1.0,
-    c2: 1.0,
-  });
+  const [weights, setWeights] = useState(
+    () =>
+      urlConfig.weights ?? {
+        a1: 1.0,
+        a2: 1.0,
+        b1: 1.0,
+        b2: 1.0,
+        c1: 1.0,
+        c2: 1.0,
+      },
+  );
 
   // FPS counter. The rAF loop is owned by this effect and cancelled in cleanup;
   // it must NOT self-gate on the `isRunning` closure (that value is captured at
@@ -604,6 +616,20 @@ function MainSimulator() {
           <SaveLoadPanel
             getCurrentData={getCurrentSimulationData}
             onLoadData={loadSimulationData}
+          />
+          <ShareConfigButton
+            getConfig={() => ({
+              latticeSize,
+              stepsPerFrame,
+              temperature,
+              boundaryCondition,
+              dwbcType,
+              renderMode,
+              showGrid,
+              animateFlips,
+              seed,
+              weights,
+            })}
           />
         </CollapsiblePanel>
       </div>

--- a/client/src/components/ShareConfigButton.tsx
+++ b/client/src/components/ShareConfigButton.tsx
@@ -1,0 +1,83 @@
+/**
+ * "Copy share link" button (issue #60).
+ *
+ * Encodes the current simulator config into the URL, copies that link to the
+ * clipboard, and reflects it in the address bar so the page itself is shareable.
+ * The lattice state is not encoded — a config + seed reproduces the run.
+ */
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { buildShareUrl, encodeConfig, type ShareableConfig } from '../lib/six-vertex/configUrl';
+import './SaveLoadPanel.css';
+
+interface ShareConfigButtonProps {
+  /** Returns the current config to encode at click time (always up to date). */
+  getConfig: () => ShareableConfig;
+}
+
+export const ShareConfigButton: React.FC<ShareConfigButtonProps> = ({ getConfig }) => {
+  const [status, setStatus] = useState<'idle' | 'copied' | 'error'>('idle');
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const flash = useCallback((next: 'copied' | 'error') => {
+    setStatus(next);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setStatus('idle'), 2000);
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    const config = getConfig();
+    const url = buildShareUrl(config, window.location.href);
+
+    // Reflect the config in the address bar without reloading or adding history.
+    window.history.replaceState(null, '', `?${encodeConfig(config).toString()}`);
+
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+        flash('copied');
+      } else {
+        // Older browsers / insecure contexts: the URL is at least in the bar.
+        flash('error');
+      }
+    } catch {
+      flash('error');
+    }
+  }, [getConfig, flash]);
+
+  const label =
+    status === 'copied'
+      ? 'Link copied!'
+      : status === 'error'
+        ? 'Copied to address bar'
+        : 'Copy share link';
+
+  return (
+    <div className="save-load-section">
+      <div className="save-load-panel">
+        <div className="save-load-panel__section">
+          <h4>Share</h4>
+          <p className="save-load-panel__hint">
+            Copy a link that reproduces this exact configuration and seed.
+          </p>
+          <button
+            type="button"
+            className="save-load-panel__button save-load-panel__button--primary"
+            onClick={handleShare}
+            aria-live="polite"
+          >
+            {label}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ShareConfigButton;

--- a/client/src/lib/six-vertex/configUrl.ts
+++ b/client/src/lib/six-vertex/configUrl.ts
@@ -1,0 +1,160 @@
+/**
+ * Shareable-config URL codec (issue #60).
+ *
+ * Encodes the user-facing simulator configuration (size, weights, seed, render
+ * options …) into compact URL query params so a run is reproducible from a link,
+ * and decodes+validates them back. Decoding is defensive: unknown params are
+ * ignored and out-of-range / malformed values are dropped (never throws), so a
+ * hand-edited or stale link degrades to defaults rather than breaking the app.
+ *
+ * The lattice STATE is intentionally not encoded — a config + seed reproduces
+ * the run deterministically, which keeps links short. (Full-state sharing is the
+ * job of the JSON import/export in SaveLoadPanel.)
+ */
+
+import { BoundaryCondition, RenderMode } from './types';
+
+export interface ShareableConfig {
+  latticeSize: number;
+  stepsPerFrame: number;
+  temperature: number;
+  boundaryCondition: BoundaryCondition;
+  dwbcType: 'high' | 'low';
+  renderMode: RenderMode;
+  showGrid: boolean;
+  animateFlips: boolean;
+  seed: number;
+  weights: { a1: number; a2: number; b1: number; b2: number; c1: number; c2: number };
+}
+
+// Hard bounds mirror the UI controls so a link can't drive the app out of range.
+const SIZE_MIN = 2;
+const SIZE_MAX = 2048;
+const SPF_MIN = 1;
+const SPF_MAX = 100000;
+const TEMP_MIN = 0.01;
+const TEMP_MAX = 100;
+const WEIGHT_MIN = 0;
+const WEIGHT_MAX = 1000;
+const WEIGHT_KEYS = ['a1', 'a2', 'b1', 'b2', 'c1', 'c2'] as const;
+
+// Short query keys keep links compact.
+const KEY = {
+  size: 'n',
+  stepsPerFrame: 'spf',
+  temperature: 't',
+  boundaryCondition: 'bc',
+  dwbcType: 'dw',
+  renderMode: 'rm',
+  showGrid: 'g',
+  animateFlips: 'af',
+  seed: 's',
+  weights: 'w', // "a1,a2,b1,b2,c1,c2"
+} as const;
+
+const BOUNDARY_VALUES = Object.values(BoundaryCondition) as string[];
+const RENDER_VALUES = Object.values(RenderMode) as string[];
+
+function clampInt(raw: string | null, min: number, max: number): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return undefined;
+  if (n < min || n > max) return undefined;
+  return n;
+}
+
+function clampFloat(raw: string | null, min: number, max: number): number | undefined {
+  if (raw === null) return undefined;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < min || n > max) return undefined;
+  return n;
+}
+
+function parseBool(raw: string | null): boolean | undefined {
+  if (raw === '1' || raw === 'true') return true;
+  if (raw === '0' || raw === 'false') return false;
+  return undefined;
+}
+
+/** Encode a config into URL query params (compact, lossless for in-range values). */
+export function encodeConfig(config: ShareableConfig): URLSearchParams {
+  const p = new URLSearchParams();
+  p.set(KEY.size, String(config.latticeSize));
+  p.set(KEY.stepsPerFrame, String(config.stepsPerFrame));
+  p.set(KEY.temperature, String(config.temperature));
+  p.set(KEY.boundaryCondition, config.boundaryCondition);
+  p.set(KEY.dwbcType, config.dwbcType);
+  p.set(KEY.renderMode, config.renderMode);
+  p.set(KEY.showGrid, config.showGrid ? '1' : '0');
+  p.set(KEY.animateFlips, config.animateFlips ? '1' : '0');
+  p.set(KEY.seed, String(config.seed));
+  p.set(KEY.weights, WEIGHT_KEYS.map((k) => config.weights[k]).join(','));
+  return p;
+}
+
+/**
+ * Decode a partial config from URL params. Returns only the fields that were
+ * present AND valid; callers spread this over their defaults. Never throws.
+ */
+export function decodeConfig(params: URLSearchParams): Partial<ShareableConfig> {
+  const out: Partial<ShareableConfig> = {};
+
+  const size = clampInt(params.get(KEY.size), SIZE_MIN, SIZE_MAX);
+  if (size !== undefined) out.latticeSize = size;
+
+  const spf = clampInt(params.get(KEY.stepsPerFrame), SPF_MIN, SPF_MAX);
+  if (spf !== undefined) out.stepsPerFrame = spf;
+
+  const temp = clampFloat(params.get(KEY.temperature), TEMP_MIN, TEMP_MAX);
+  if (temp !== undefined) out.temperature = temp;
+
+  const bc = params.get(KEY.boundaryCondition);
+  if (bc !== null && BOUNDARY_VALUES.includes(bc)) out.boundaryCondition = bc as BoundaryCondition;
+
+  const dw = params.get(KEY.dwbcType);
+  if (dw === 'high' || dw === 'low') out.dwbcType = dw;
+
+  const rm = params.get(KEY.renderMode);
+  if (rm !== null && RENDER_VALUES.includes(rm)) out.renderMode = rm as RenderMode;
+
+  const g = parseBool(params.get(KEY.showGrid));
+  if (g !== undefined) out.showGrid = g;
+
+  const af = parseBool(params.get(KEY.animateFlips));
+  if (af !== undefined) out.animateFlips = af;
+
+  const seed = clampInt(params.get(KEY.seed), 0, Number.MAX_SAFE_INTEGER);
+  if (seed !== undefined) out.seed = seed;
+
+  const w = params.get(KEY.weights);
+  if (w !== null) {
+    const parts = w.split(',');
+    if (parts.length === WEIGHT_KEYS.length) {
+      const vals = parts.map((s) => Number(s));
+      if (vals.every((v) => Number.isFinite(v) && v >= WEIGHT_MIN && v <= WEIGHT_MAX)) {
+        out.weights = {
+          a1: vals[0],
+          a2: vals[1],
+          b1: vals[2],
+          b2: vals[3],
+          c1: vals[4],
+          c2: vals[5],
+        };
+      }
+    }
+  }
+
+  return out;
+}
+
+/** Build a full shareable URL for the given config against a base href. */
+export function buildShareUrl(config: ShareableConfig, baseHref: string): string {
+  const url = new URL(baseHref);
+  url.search = encodeConfig(config).toString();
+  return url.toString();
+}
+
+/** Decode whatever config is present in a location's query string. */
+export function readConfigFromSearch(search: string): Partial<ShareableConfig> {
+  return decodeConfig(new URLSearchParams(search));
+}

--- a/client/tests/six-vertex/configUrl.test.ts
+++ b/client/tests/six-vertex/configUrl.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the shareable-config URL codec (issue #60).
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  encodeConfig,
+  decodeConfig,
+  buildShareUrl,
+  readConfigFromSearch,
+  type ShareableConfig,
+} from '../../src/lib/six-vertex/configUrl';
+import { BoundaryCondition, RenderMode } from '../../src/lib/six-vertex/types';
+
+const sample: ShareableConfig = {
+  latticeSize: 24,
+  stepsPerFrame: 50,
+  temperature: 0.75,
+  boundaryCondition: BoundaryCondition.DWBC,
+  dwbcType: 'low',
+  renderMode: RenderMode.Both,
+  showGrid: false,
+  animateFlips: true,
+  seed: 987654,
+  weights: { a1: 1, a2: 1.5, b1: 2, b2: 0.5, c1: 1.25, c2: 3 },
+};
+
+describe('configUrl codec', () => {
+  it('round-trips a full config losslessly', () => {
+    const decoded = decodeConfig(encodeConfig(sample));
+    expect(decoded).toEqual(sample);
+  });
+
+  it('buildShareUrl produces a parseable URL that decodes back', () => {
+    const url = buildShareUrl(sample, 'https://6v.allison.la/');
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe('https://6v.allison.la/');
+    expect(decodeConfig(parsed.searchParams)).toEqual(sample);
+  });
+
+  it('returns an empty object for an empty query', () => {
+    expect(decodeConfig(new URLSearchParams(''))).toEqual({});
+    expect(readConfigFromSearch('')).toEqual({});
+  });
+
+  it('returns only the fields present (partial config)', () => {
+    const decoded = readConfigFromSearch('?n=16&s=42');
+    expect(decoded).toEqual({ latticeSize: 16, seed: 42 });
+  });
+
+  it('drops out-of-range and malformed values rather than throwing', () => {
+    // size below min, temperature above max, fractional steps, bad enum, short weights
+    const decoded = readConfigFromSearch(
+      '?n=1&t=999&spf=2.5&bc=banana&rm=hologram&dw=sideways&w=1,2,3&g=maybe&s=-4',
+    );
+    expect(decoded).toEqual({});
+  });
+
+  it('accepts boolean aliases (1/0, true/false)', () => {
+    expect(readConfigFromSearch('?g=true&af=0')).toEqual({ showGrid: true, animateFlips: false });
+    expect(readConfigFromSearch('?g=1&af=false')).toEqual({ showGrid: true, animateFlips: false });
+  });
+
+  it('rejects a weights list with the wrong arity or a negative weight', () => {
+    expect(readConfigFromSearch('?w=1,2,3,4,5')).toEqual({}); // 5 entries
+    expect(readConfigFromSearch('?w=1,1,1,1,1,-1')).toEqual({}); // negative
+    expect(readConfigFromSearch('?w=0,0,0,0,0,0')).toEqual({
+      weights: { a1: 0, a2: 0, b1: 0, b2: 0, c1: 0, c2: 0 },
+    }); // zero is allowed
+  });
+
+  it('ignores unknown params', () => {
+    expect(readConfigFromSearch('?n=8&unknown=xyz&foo=1')).toEqual({ latticeSize: 8 });
+  });
+});


### PR DESCRIPTION
## 🚀 Preview Deployment
**Preview URL:** https://pr-82.dev.6v.allison.la

## Summary
First half of EPIC #54's polish item (#60): **shareable config links**. The simulator configuration (lattice size, steps/frame, temperature, boundary + DWBC type, render mode, grid/animate toggles, seed, and the six vertex weights) is encoded into compact URL query params so a run is reproducible from a link. On load, `MainSimulator` seeds its state from the URL; a **Copy share link** button in the Info panel copies the link and reflects it in the address bar.

## Changes
- **`configUrl.ts`** — pure, defensive codec. `encode` is lossless for in-range values; `decode` validates every field (range + enum + weight arity), ignores unknown params, and **never throws** (a stale/hand-edited link degrades to defaults). Lattice *state* is intentionally not encoded — config + seed reproduces the run deterministically (full-state sharing remains the JSON export's job), keeping links short.
- **`ShareConfigButton.tsx`** — builds + copies the link, updates the address bar via `history.replaceState`, transient "copied" feedback, clipboard fallback for insecure contexts.
- **`MainSimulator.tsx`** — lazy `useState` initializers read the decoded URL config.
- **8 codec tests** — round-trip, partial config, malformed/out-of-range dropping, boolean aliases, weight arity/negative rejection, unknown-param ignoring.

## Testing
- [x] Full suite green (385 → **393**)
- [x] `tsc` / ESLint / `vite build` clean
- [x] In-browser: opening `?n=20&t=0.5&dw=low&rm=both&g=0&s=42&w=1,1,1,1,2,2` restores size 20, temp 0.5, seed 42, weights (c1=c2=2), `dwbc`/`both` selects, grid off; the Share button writes the full canonical link to the address bar; console clean

## Related Issues
Refs #60 (the N-sim diff/overlay half follows in a separate PR), EPIC #54
